### PR TITLE
Add working manifest URIs to data file and use them

### DIFF
--- a/_data/handles.csv
+++ b/_data/handles.csv
@@ -1,205 +1,205 @@
-signatuur,handle
-BPL 3,https://hdl.handle.net/1887.1/item:939291
-BPL 14 A,https://hdl.handle.net/1887.1/item:1602664
-BPL 1291,https://hdl.handle.net/1887.1/item:1518587
-BPL 2473,https://hdl.handle.net/1887.1/item:880792
-BPL 2474,https://hdl.handle.net/1887.1/item:1525134
-BPL 2541,https://hdl.handle.net/1887.1/item:1525817
-LTK 194,https://hdl.handle.net/1887.1/item:1595455
-LTK 208,https://hdl.handle.net/1887.1/item:1596163
-LTK 219,https://hdl.handle.net/1887.1/item:1518381
-LTK 226,https://hdl.handle.net/1887.1/item:1517669
-LTK 261,https://hdl.handle.net/1887.1/item:1507840
-LTK 268,https://hdl.handle.net/1887.1/item:1517527
-LTK 294,https://hdl.handle.net/1887.1/item:1518192
-LTK 335,https://hdl.handle.net/1887.1/item:1517393
-LTK 356,https://hdl.handle.net/1887.1/item:1517967
-LTK 360,https://hdl.handle.net/1887.1/item:1526173
-LTK 854,https://hdl.handle.net/1887.1/item:1518680
-LTK 856,https://hdl.handle.net/1887.1/item:936120
-LTK 1019,https://hdl.handle.net/1887.1/item:877816
-LTK 1296,https://hdl.handle.net/1887.1/item:1518921
-LTK 1341,https://hdl.handle.net/1887.1/item:1601978
-LTK 1511,https://hdl.handle.net/1887.1/item:1508153
-LTK 1532,https://hdl.handle.net/1887.1/item:1507621
-LTK 2156,https://hdl.handle.net/1887.1/item:1517626
-LTK 2290,https://hdl.handle.net/1887.1/item:1517769
-BPL 25,https://hdl.handle.net/1887.1/item:1617684
-BPL 28,https://hdl.handle.net/1887.1/item:1652555
-BPL 43 A,https://hdl.handle.net/1887.1/item:1617735
-BPL 46,https://hdl.handle.net/1887.1/item:1618024
-BPL 52,https://hdl.handle.net/1887.1/item:1670301
-BPL 78,https://hdl.handle.net/1887.1/item:1667444
-BPL 85,https://hdl.handle.net/1887.1/item:1667479
-BPL 87,https://hdl.handle.net/1887.1/item:1667299
-BPL 141,https://hdl.handle.net/1887.1/item:1667735
-BPL 148,https://hdl.handle.net/1887.1/item:1616737
-BPL 177,https://hdl.handle.net/1887.1/item:1669264
-BPL 199,https://hdl.handle.net/1887.1/item:1617143
-BPL 1925,https://hdl.handle.net/1887.1/item:877637
-BPL 2011,https://hdl.handle.net/1887.1/item:1667894
-BUR Q 31,https://hdl.handle.net/1887.1/item:1617450
-GRO 20,https://hdl.handle.net/1887.1/item:1617131
-GRO 22,https://hdl.handle.net/1887.1/item:1668135
-LIP 30,https://hdl.handle.net/1887.1/item:1652048
-LIP 49,https://hdl.handle.net/1887.1/item:1670145
-PER F 25,https://hdl.handle.net/1887.1/item:1652122
-PER F 5,https://hdl.handle.net/1887.1/item:1668866
-PER Q 7,https://hdl.handle.net/1887.1/item:1669380
-PER O 4 A,https://hdl.handle.net/1887.1/item:1652459
-VUL 90 B,https://hdl.handle.net/1887.1/item:1667262
-SCA 69,https://hdl.handle.net/1887.1/item:1669458
-BPL 76 C,https://hdl.handle.net/1887.1/item:1686975
-BPL 127 D,https://hdl.handle.net/1887.1/item:1678412
-BPL 136 D,https://hdl.handle.net/1887.1/item:1594995
-BPL 2894,https://hdl.handle.net/1887.1/item:1679726
-BPL 3382,https://hdl.handle.net/1887.1/item:1679119
-BPL 3477,https://hdl.handle.net/1887.1/item:1672013
-GRO 16,https://hdl.handle.net/1887.1/item:1681083
-GRO 67,https://hdl.handle.net/1887.1/item:1679207
-LIP 50,https://hdl.handle.net/1887.1/item:1653808
-LTK 168,https://hdl.handle.net/1887.1/item:1678947
-LTK 611,https://hdl.handle.net/1887.1/item:881537
-LTK 1028,https://hdl.handle.net/1887.1/item:1678075
-LTK 1031,https://hdl.handle.net/1887.1/item:1681237
-PER F 18,https://hdl.handle.net/1887.1/item:1668693
-SCA 14,https://hdl.handle.net/1887.1/item:1678556
-VCQ 30,https://hdl.handle.net/1887.1/item:1680639
-BPG 49 A,https://hdl.handle.net/1887.1/item:878785
-BPL 48,https://hdl.handle.net/1887.1/item:1606013
-BPL 90,https://hdl.handle.net/1887.1/item:1681482
-BPL 109,https://hdl.handle.net/1887.1/item:1678256
-BPL 111: 1,https://hdl.handle.net/1887.1/item:1668257
-BPL 111: 2,https://hdl.handle.net/1887.1/item:1653716
-BPL 118,https://hdl.handle.net/1887.1/item:848447
-BPL 126,https://hdl.handle.net/1887.1/item:1680068
-BPL 138,https://hdl.handle.net/1887.1/item:1668926
-BPL 178,https://hdl.handle.net/1887.1/item:1668518
-BPL 191 C,https://hdl.handle.net/1887.1/item:1680866
-BPL 198 A,https://hdl.handle.net/1887.1/item:1680232
-BPL 217,https://hdl.handle.net/1887.1/item:1679787
-BPL 2391: b,https://hdl.handle.net/1887.1/item:1681574
-BPL 2508,https://hdl.handle.net/1887.1/item:1680146
-LTK 231,https://hdl.handle.net/1887.1/item:1806195
-LTK 337,https://hdl.handle.net/1887.1/item:1671423
-BPL 4,https://hdl.handle.net/1887.1/item:1679348
-BPL 1800,https://hdl.handle.net/1887.1/item:1669863
-BPL 1949,https://hdl.handle.net/1887.1/item:1667560
-BPL 2905,https://hdl.handle.net/1887.1/item:1669553
-BPL 2231,https://hdl.handle.net/1887.1/item:1669105
-BPL 2480,https://hdl.handle.net/1887.1/item:1671012
-BPL 2482,https://hdl.handle.net/1887.1/item:1670753
-BPL 2483,https://hdl.handle.net/1887.1/item:1670422
-BPL 2627,https://hdl.handle.net/1887.1/item:848872
-BPL 2706,https://hdl.handle.net/1887.1/item:1671155
-BPL 2782,https://hdl.handle.net/1887.1/item:1672344
-BPL 2795,https://hdl.handle.net/1887.1/item:1671906
-BPL 2851,https://hdl.handle.net/1887.1/item:1671113
-BPL 2856,https://hdl.handle.net/1887.1/item:1672425
-LTK 218,https://hdl.handle.net/1887.1/item:1686174
-LTK 237,https://hdl.handle.net/1887.1/item:1686774
-LTK 247,https://hdl.handle.net/1887.1/item:1687530
-LTK 263,https://hdl.handle.net/1887.1/item:1684431
-LTK 278,https://hdl.handle.net/1887.1/item:1687148
-LTK 284,https://hdl.handle.net/1887.1/item:1685930
-LTK 304,https://hdl.handle.net/1887.1/item:1687308
-LTK 316,https://hdl.handle.net/1887.1/item:1686299
-LTK 318,https://hdl.handle.net/1887.1/item:1685644
-LTK 336,https://hdl.handle.net/1887.1/item:1685390
-ABL 14,https://hdl.handle.net/1887.1/item:1684659
-BPL 17,https://hdl.handle.net/1887.1/item:1686413
-BPL 43,https://hdl.handle.net/1887.1/item:1685155
-BPL 91,https://hdl.handle.net/1887.1/item:1686587
-BPL 137 D,https://hdl.handle.net/1887.1/item:1686524
-BPL 139 B,https://hdl.handle.net/1887.1/item:1687093
-BPL 154,https://hdl.handle.net/1887.1/item:1684739
-BPL 164,https://hdl.handle.net/1887.1/item:1684621
-BPL 186,https://hdl.handle.net/1887.1/item:1685282
-BPL 191 A,https://hdl.handle.net/1887.1/item:1684869
-BPL 191 BD,https://hdl.handle.net/1887.1/item:1686262
-BPL 191 E,https://hdl.handle.net/1887.1/item:884522
-BPL 194,https://hdl.handle.net/1887.1/item:1805705
-BPL 195,https://hdl.handle.net/1887.1/item:1805142
-BPL 197,https://hdl.handle.net/1887.1/item:1805480
-BPL 225,https://hdl.handle.net/1887.1/item:1805059
-BPL 226,https://hdl.handle.net/1887.1/item:1806126
-BPL 304,https://hdl.handle.net/1887.1/item:1804771
-BPL 1015,https://hdl.handle.net/1887.1/item:1805760
-BPL 1715,https://hdl.handle.net/1887.1/item:1805241
-BPL 1765,https://hdl.handle.net/1887.1/item:1805895
-GRO 6,https://hdl.handle.net/1887.1/item:1805345
-GRO 38,https://hdl.handle.net/1887.1/item:1805791
-PER Q 85,https://hdl.handle.net/1887.1/item:1805562
-SCA 1,https://hdl.handle.net/1887.1/item:1805678
-BPL 38 F,https://hdl.handle.net/1887.1/item:1837039
-BPL 45,https://hdl.handle.net/1887.1/item:1837371
-BPL 100 A,https://hdl.handle.net/1887.1/item:1837299
-BPL 121,https://hdl.handle.net/1887.1/item:1838361
-BPL 1905,https://hdl.handle.net/1887.1/item:881513
-BPL 1956,https://hdl.handle.net/1887.1/item:1837854
-BPL 3094,https://hdl.handle.net/1887.1/item:1616858
-BPL 3103,https://hdl.handle.net/1887.1/item:1837757
-BPL 3284,https://hdl.handle.net/1887.1/item:1838428
-LTK 169,https://hdl.handle.net/1887.1/item:1839168
-LTK 233,https://hdl.handle.net/1887.1/item:885149
-LTK 287,https://hdl.handle.net/1887.1/item:1838587
-LTK 303,https://hdl.handle.net/1887.1/item:1838926
-LTK 1104,https://hdl.handle.net/1887.1/item:1838135
-Or. 4725,https://hdl.handle.net/1887.1/item:1836971
-SCA 54,https://hdl.handle.net/1887.1/item:1885015
-VCF 11,https://hdl.handle.net/1887.1/item:1879191
-VCF 6,https://hdl.handle.net/1887.1/item:1882818
-VCQ 13,https://hdl.handle.net/1887.1/item:1883282
-VCQ 37,https://hdl.handle.net/1887.1/item:1878906
-VGG F 9,https://hdl.handle.net/1887.1/item:1885014
-ABL 28,https://hdl.handle.net/1887.1/item:1881569
-BPL 11 D,https://hdl.handle.net/1887.1/item:1880842
-BPL 127 AC,https://hdl.handle.net/1887.1/item:1879505
-BPL 146,https://hdl.handle.net/1887.1/item:1885782
-BPL 1813,https://hdl.handle.net/1887.1/item:1879098
-BPL 182,https://hdl.handle.net/1887.1/item:1881388
-BPL 2658,https://hdl.handle.net/1887.1/item:1886573
-BPL 2716,https://hdl.handle.net/1887.1/item:1885928
-BPL 2887,https://hdl.handle.net/1887.1/item:1886303
-BPL 3179,https://hdl.handle.net/1887.1/item:1885468
-LIP 53,https://hdl.handle.net/1887.1/item:1885734
-MEY 4,https://hdl.handle.net/1887.1/item:1885530
-VCF 12,https://hdl.handle.net/1887.1/item:1889899
-VCF 13,https://hdl.handle.net/1887.1/item:1889437
-VCF 14,https://hdl.handle.net/1887.1/item:1914511
-VCF 15,https://hdl.handle.net/1887.1/item:1913677
-VCF 16,https://hdl.handle.net/1887.1/item:1913524
-VCF 17,https://hdl.handle.net/1887.1/item:1914032
-VCF 18,https://hdl.handle.net/1887.1/item:1913108
-VCF 20,https://hdl.handle.net/1887.1/item:1940086
-VCF 21,https://hdl.handle.net/1887.1/item:1937723
-VCF 22,https://hdl.handle.net/1887.1/item:1939389
-VCF 23,https://hdl.handle.net/1887.1/item:1937165
-VCF 8,https://hdl.handle.net/1887.1/item:1938821
-VUL 91 B,https://hdl.handle.net/1887.1/item:1937686
-1365 A 15,https://hdl.handle.net/1887.1/item:1987457
-1365 G 14,https://hdl.handle.net/1887.1/item:1941531
-1367 C 12,https://hdl.handle.net/1887.1/item:1941357
-1367 C 16,https://hdl.handle.net/1887.1/item:1941419
-1369 C 7,https://hdl.handle.net/1887.1/item:1936866
-1496 C 13,https://hdl.handle.net/1887.1/item:1939696
-1497 B 11,https://hdl.handle.net/1887.1/item:1936602
-1497 B 12,https://hdl.handle.net/1887.1/item:1938202
-1497 E 4,https://hdl.handle.net/1887.1/item:1941632
-1497 G 42,https://hdl.handle.net/1887.1/item:1940710
-1497 G 43,https://hdl.handle.net/1887.1/item:1940494
-1498 B 1,https://hdl.handle.net/1887.1/item:1941744
-1498 B 10,https://hdl.handle.net/1887.1/item:1940992
-1498 B 2,https://hdl.handle.net/1887.1/item:1938676
-1498 C 4,https://hdl.handle.net/1887.1/item:1981076
-1498 F 1,https://hdl.handle.net/1887.1/item:1981839
-1407 A 2-3,https://hdl.handle.net/1887.1/item:1987448
-1498 B 11-12,https://hdl.handle.net/1887.1/item:1987449
-1367 B 14: 1,https://hdl.handle.net/1887.1/item:1982012
-1367 B 14: 2,https://hdl.handle.net/1887.1/item:1980929
-1368 D 21: 1,https://hdl.handle.net/1887.1/item:1981273
-1368 D 21: 2,https://hdl.handle.net/1887.1/item:1981068
-1368 D 21: 3,https://hdl.handle.net/1887.1/item:1981820
-1370 E 16: 1,https://hdl.handle.net/1887.1/item:1981739
-1370 E 16: 2,https://hdl.handle.net/1887.1/item:1979734
-BPL 1010,https://hdl.handle.net/1887.1/item:1989383
+signatuur,handle,manifest
+BPL 3,https://hdl.handle.net/1887.1/item:939291,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:939291/manifest
+BPL 14 A,https://hdl.handle.net/1887.1/item:1602664,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1602664/manifest
+BPL 1291,https://hdl.handle.net/1887.1/item:1518587,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1518587/manifest
+BPL 2473,https://hdl.handle.net/1887.1/item:880792,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:880792/manifest
+BPL 2474,https://hdl.handle.net/1887.1/item:1525134,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1525134/manifest
+BPL 2541,https://hdl.handle.net/1887.1/item:1525817,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1525817/manifest
+LTK 194,https://hdl.handle.net/1887.1/item:1595455,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1595455/manifest
+LTK 208,https://hdl.handle.net/1887.1/item:1596163,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1596163/manifest
+LTK 219,https://hdl.handle.net/1887.1/item:1518381,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1518381/manifest
+LTK 226,https://hdl.handle.net/1887.1/item:1517669,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1517669/manifest
+LTK 261,https://hdl.handle.net/1887.1/item:1507840,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1507840/manifest
+LTK 268,https://hdl.handle.net/1887.1/item:1517527,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1517527/manifest
+LTK 294,https://hdl.handle.net/1887.1/item:1518192,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1518192/manifest
+LTK 335,https://hdl.handle.net/1887.1/item:1517393,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1517393/manifest
+LTK 356,https://hdl.handle.net/1887.1/item:1517967,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1517967/manifest
+LTK 360,https://hdl.handle.net/1887.1/item:1526173,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1526173/manifest
+LTK 854,https://hdl.handle.net/1887.1/item:1518680,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1518680/manifest
+LTK 856,https://hdl.handle.net/1887.1/item:936120,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:936120/manifest
+LTK 1019,https://hdl.handle.net/1887.1/item:877816,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:877816/manifest
+LTK 1296,https://hdl.handle.net/1887.1/item:1518921,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1518921/manifest
+LTK 1341,https://hdl.handle.net/1887.1/item:1601978,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1601978/manifest
+LTK 1511,https://hdl.handle.net/1887.1/item:1508153,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1508153/manifest
+LTK 1532,https://hdl.handle.net/1887.1/item:1507621,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1507621/manifest
+LTK 2156,https://hdl.handle.net/1887.1/item:1517626,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1517626/manifest
+LTK 2290,https://hdl.handle.net/1887.1/item:1517769,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1517769/manifest
+BPL 25,https://hdl.handle.net/1887.1/item:1617684,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1617684/manifest
+BPL 28,https://hdl.handle.net/1887.1/item:1652555,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1652555/manifest
+BPL 43 A,https://hdl.handle.net/1887.1/item:1617735,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1617735/manifest
+BPL 46,https://hdl.handle.net/1887.1/item:1618024,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1618024/manifest
+BPL 52,https://hdl.handle.net/1887.1/item:1670301,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1670301/manifest
+BPL 78,https://hdl.handle.net/1887.1/item:1667444,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1667444/manifest
+BPL 85,https://hdl.handle.net/1887.1/item:1667479,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1667479/manifest
+BPL 87,https://hdl.handle.net/1887.1/item:1667299,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1667299/manifest
+BPL 141,https://hdl.handle.net/1887.1/item:1667735,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1667735/manifest
+BPL 148,https://hdl.handle.net/1887.1/item:1616737,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1616737/manifest
+BPL 177,https://hdl.handle.net/1887.1/item:1669264,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1669264/manifest
+BPL 199,https://hdl.handle.net/1887.1/item:1617143,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1617143/manifest
+BPL 1925,https://hdl.handle.net/1887.1/item:877637,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:877637/manifest
+BPL 2011,https://hdl.handle.net/1887.1/item:1667894,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1667894/manifest
+BUR Q 31,https://hdl.handle.net/1887.1/item:1617450,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1617450/manifest
+GRO 20,https://hdl.handle.net/1887.1/item:1617131,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1617131/manifest
+GRO 22,https://hdl.handle.net/1887.1/item:1668135,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1668135/manifest
+LIP 30,https://hdl.handle.net/1887.1/item:1652048,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1652048/manifest
+LIP 49,https://hdl.handle.net/1887.1/item:1670145,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1670145/manifest
+PER F 25,https://hdl.handle.net/1887.1/item:1652122,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1652122/manifest
+PER F 5,https://hdl.handle.net/1887.1/item:1668866,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1668866/manifest
+PER Q 7,https://hdl.handle.net/1887.1/item:1669380,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1669380/manifest
+PER O 4 A,https://hdl.handle.net/1887.1/item:1652459,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1652459/manifest
+VUL 90 B,https://hdl.handle.net/1887.1/item:1667262,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1667262/manifest
+SCA 69,https://hdl.handle.net/1887.1/item:1669458,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1669458/manifest
+BPL 76 C,https://hdl.handle.net/1887.1/item:1686975,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1686975/manifest
+BPL 127 D,https://hdl.handle.net/1887.1/item:1678412,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1678412/manifest
+BPL 136 D,https://hdl.handle.net/1887.1/item:1594995,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1594995/manifest
+BPL 2894,https://hdl.handle.net/1887.1/item:1679726,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1679726/manifest
+BPL 3382,https://hdl.handle.net/1887.1/item:1679119,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1679119/manifest
+BPL 3477,https://hdl.handle.net/1887.1/item:1672013,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1672013/manifest
+GRO 16,https://hdl.handle.net/1887.1/item:1681083,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1681083/manifest
+GRO 67,https://hdl.handle.net/1887.1/item:1679207,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1679207/manifest
+LIP 50,https://hdl.handle.net/1887.1/item:1653808,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1653808/manifest
+LTK 168,https://hdl.handle.net/1887.1/item:1678947,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1678947/manifest
+LTK 611,https://hdl.handle.net/1887.1/item:881537,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:881537/manifest
+LTK 1028,https://hdl.handle.net/1887.1/item:1678075,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1678075/manifest
+LTK 1031,https://hdl.handle.net/1887.1/item:1681237,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1681237/manifest
+PER F 18,https://hdl.handle.net/1887.1/item:1668693,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1668693/manifest
+SCA 14,https://hdl.handle.net/1887.1/item:1678556,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1678556/manifest
+VCQ 30,https://hdl.handle.net/1887.1/item:1680639,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1680639/manifest
+BPG 49 A,https://hdl.handle.net/1887.1/item:878785,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:878785/manifest
+BPL 48,https://hdl.handle.net/1887.1/item:1606013,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1606013/manifest
+BPL 90,https://hdl.handle.net/1887.1/item:1681482,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1681482/manifest
+BPL 109,https://hdl.handle.net/1887.1/item:1678256,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1678256/manifest
+BPL 111: 1,https://hdl.handle.net/1887.1/item:1668257,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1668257/manifest
+BPL 111: 2,https://hdl.handle.net/1887.1/item:1653716,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1653716/manifest
+BPL 118,https://hdl.handle.net/1887.1/item:848447,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:848447/manifest
+BPL 126,https://hdl.handle.net/1887.1/item:1680068,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1680068/manifest
+BPL 138,https://hdl.handle.net/1887.1/item:1668926,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1668926/manifest
+BPL 178,https://hdl.handle.net/1887.1/item:1668518,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1668518/manifest
+BPL 191 C,https://hdl.handle.net/1887.1/item:1680866,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1680866/manifest
+BPL 198 A,https://hdl.handle.net/1887.1/item:1680232,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1680232/manifest
+BPL 217,https://hdl.handle.net/1887.1/item:1679787,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1679787/manifest
+BPL 2391: b,https://hdl.handle.net/1887.1/item:1681574,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1681574/manifest
+BPL 2508,https://hdl.handle.net/1887.1/item:1680146,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1680146/manifest
+LTK 231,https://hdl.handle.net/1887.1/item:1806195,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1806195/manifest
+LTK 337,https://hdl.handle.net/1887.1/item:1671423,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1671423/manifest
+BPL 4,https://hdl.handle.net/1887.1/item:1679348,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1679348/manifest
+BPL 1800,https://hdl.handle.net/1887.1/item:1669863,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1669863/manifest
+BPL 1949,https://hdl.handle.net/1887.1/item:1667560,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1667560/manifest
+BPL 2905,https://hdl.handle.net/1887.1/item:1669553,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1669553/manifest
+BPL 2231,https://hdl.handle.net/1887.1/item:1669105,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1669105/manifest
+BPL 2480,https://hdl.handle.net/1887.1/item:1671012,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1671012/manifest
+BPL 2482,https://hdl.handle.net/1887.1/item:1670753,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1670753/manifest
+BPL 2483,https://hdl.handle.net/1887.1/item:1670422,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1670422/manifest
+BPL 2627,https://hdl.handle.net/1887.1/item:848872,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:848872/manifest
+BPL 2706,https://hdl.handle.net/1887.1/item:1671155,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1671155/manifest
+BPL 2782,https://hdl.handle.net/1887.1/item:1672344,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1672344/manifest
+BPL 2795,https://hdl.handle.net/1887.1/item:1671906,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1671906/manifest
+BPL 2851,https://hdl.handle.net/1887.1/item:1671113,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1671113/manifest
+BPL 2856,https://hdl.handle.net/1887.1/item:1672425,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1672425/manifest
+LTK 218,https://hdl.handle.net/1887.1/item:1686174,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1686174/manifest
+LTK 237,https://hdl.handle.net/1887.1/item:1686774,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1686774/manifest
+LTK 247,https://hdl.handle.net/1887.1/item:1687530,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1687530/manifest
+LTK 263,https://hdl.handle.net/1887.1/item:1684431,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1684431/manifest
+LTK 278,https://hdl.handle.net/1887.1/item:1687148,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1687148/manifest
+LTK 284,https://hdl.handle.net/1887.1/item:1685930,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1685930/manifest
+LTK 304,https://hdl.handle.net/1887.1/item:1687308,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1687308/manifest
+LTK 316,https://hdl.handle.net/1887.1/item:1686299,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1686299/manifest
+LTK 318,https://hdl.handle.net/1887.1/item:1685644,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1685644/manifest
+LTK 336,https://hdl.handle.net/1887.1/item:1685390,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1685390/manifest
+ABL 14,https://hdl.handle.net/1887.1/item:1684659,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1684659/manifest
+BPL 17,https://hdl.handle.net/1887.1/item:1686413,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1686413/manifest
+BPL 43,https://hdl.handle.net/1887.1/item:1685155,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1685155/manifest
+BPL 91,https://hdl.handle.net/1887.1/item:1686587,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1686587/manifest
+BPL 137 D,https://hdl.handle.net/1887.1/item:1686524,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1686524/manifest
+BPL 139 B,https://hdl.handle.net/1887.1/item:1687093,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1687093/manifest
+BPL 154,https://hdl.handle.net/1887.1/item:1684739,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1684739/manifest
+BPL 164,https://hdl.handle.net/1887.1/item:1684621,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1684621/manifest
+BPL 186,https://hdl.handle.net/1887.1/item:1685282,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1685282/manifest
+BPL 191 A,https://hdl.handle.net/1887.1/item:1684869,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1684869/manifest
+BPL 191 BD,https://hdl.handle.net/1887.1/item:1686262,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1686262/manifest
+BPL 191 E,https://hdl.handle.net/1887.1/item:884522,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:884522/manifest
+BPL 194,https://hdl.handle.net/1887.1/item:1805705,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1805705/manifest
+BPL 195,https://hdl.handle.net/1887.1/item:1805142,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1805142/manifest
+BPL 197,https://hdl.handle.net/1887.1/item:1805480,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1805480/manifest
+BPL 225,https://hdl.handle.net/1887.1/item:1805059,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1805059/manifest
+BPL 226,https://hdl.handle.net/1887.1/item:1806126,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1806126/manifest
+BPL 304,https://hdl.handle.net/1887.1/item:1804771,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1804771/manifest
+BPL 1015,https://hdl.handle.net/1887.1/item:1805760,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1805760/manifest
+BPL 1715,https://hdl.handle.net/1887.1/item:1805241,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1805241/manifest
+BPL 1765,https://hdl.handle.net/1887.1/item:1805895,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1805895/manifest
+GRO 6,https://hdl.handle.net/1887.1/item:1805345,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1805345/manifest
+GRO 38,https://hdl.handle.net/1887.1/item:1805791,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1805791/manifest
+PER Q 85,https://hdl.handle.net/1887.1/item:1805562,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1805562/manifest
+SCA 1,https://hdl.handle.net/1887.1/item:1805678,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1805678/manifest
+BPL 38 F,https://hdl.handle.net/1887.1/item:1837039,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1837039/manifest
+BPL 45,https://hdl.handle.net/1887.1/item:1837371,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1837371/manifest
+BPL 100 A,https://hdl.handle.net/1887.1/item:1837299,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1837299/manifest
+BPL 121,https://hdl.handle.net/1887.1/item:1838361,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1838361/manifest
+BPL 1905,https://hdl.handle.net/1887.1/item:881513,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:881513/manifest
+BPL 1956,https://hdl.handle.net/1887.1/item:1837854,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1837854/manifest
+BPL 3094,https://hdl.handle.net/1887.1/item:1616858,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1616858/manifest
+BPL 3103,https://hdl.handle.net/1887.1/item:1837757,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1837757/manifest
+BPL 3284,https://hdl.handle.net/1887.1/item:1838428,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1838428/manifest
+LTK 169,https://hdl.handle.net/1887.1/item:1839168,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1839168/manifest
+LTK 233,https://hdl.handle.net/1887.1/item:885149,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:885149/manifest
+LTK 287,https://hdl.handle.net/1887.1/item:1838587,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1838587/manifest
+LTK 303,https://hdl.handle.net/1887.1/item:1838926,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1838926/manifest
+LTK 1104,https://hdl.handle.net/1887.1/item:1838135,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1838135/manifest
+Or. 4725,https://hdl.handle.net/1887.1/item:1836971,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1836971/manifest
+SCA 54,https://hdl.handle.net/1887.1/item:1885015,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1885015/manifest
+VCF 11,https://hdl.handle.net/1887.1/item:1879191,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1879191/manifest
+VCF 6,https://hdl.handle.net/1887.1/item:1882818,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1882818/manifest
+VCQ 13,https://hdl.handle.net/1887.1/item:1883282,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1883282/manifest
+VCQ 37,https://hdl.handle.net/1887.1/item:1878906,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1878906/manifest
+VGG F 9,https://hdl.handle.net/1887.1/item:1885014,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1885014/manifest
+ABL 28,https://hdl.handle.net/1887.1/item:1881569,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1881569/manifest
+BPL 11 D,https://hdl.handle.net/1887.1/item:1880842,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1880842/manifest
+BPL 127 AC,https://hdl.handle.net/1887.1/item:1879505,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1879505/manifest
+BPL 146,https://hdl.handle.net/1887.1/item:1885782,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1885782/manifest
+BPL 1813,https://hdl.handle.net/1887.1/item:1879098,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1879098/manifest
+BPL 182,https://hdl.handle.net/1887.1/item:1881388,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1881388/manifest
+BPL 2658,https://hdl.handle.net/1887.1/item:1886573,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1886573/manifest
+BPL 2716,https://hdl.handle.net/1887.1/item:1885928,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1885928/manifest
+BPL 2887,https://hdl.handle.net/1887.1/item:1886303,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1886303/manifest
+BPL 3179,https://hdl.handle.net/1887.1/item:1885468,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1885468/manifest
+LIP 53,https://hdl.handle.net/1887.1/item:1885734,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1885734/manifest
+MEY 4,https://hdl.handle.net/1887.1/item:1885530,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1885530/manifest
+VCF 12,https://hdl.handle.net/1887.1/item:1889899,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1889899/manifest
+VCF 13,https://hdl.handle.net/1887.1/item:1889437,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1889437/manifest
+VCF 14,https://hdl.handle.net/1887.1/item:1914511,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1914511/manifest
+VCF 15,https://hdl.handle.net/1887.1/item:1913677,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1913677/manifest
+VCF 16,https://hdl.handle.net/1887.1/item:1913524,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1913524/manifest
+VCF 17,https://hdl.handle.net/1887.1/item:1914032,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1914032/manifest
+VCF 18,https://hdl.handle.net/1887.1/item:1913108,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1913108/manifest
+VCF 20,https://hdl.handle.net/1887.1/item:1940086,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1940086/manifest
+VCF 21,https://hdl.handle.net/1887.1/item:1937723,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1937723/manifest
+VCF 22,https://hdl.handle.net/1887.1/item:1939389,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1939389/manifest
+VCF 23,https://hdl.handle.net/1887.1/item:1937165,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1937165/manifest
+VCF 8,https://hdl.handle.net/1887.1/item:1938821,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1938821/manifest
+VUL 91 B,https://hdl.handle.net/1887.1/item:1937686,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1937686/manifest
+1365 A 15,https://hdl.handle.net/1887.1/item:1987457,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1987457/manifest
+1365 G 14,https://hdl.handle.net/1887.1/item:1941531,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1941531/manifest
+1367 C 12,https://hdl.handle.net/1887.1/item:1941357,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1941357/manifest
+1367 C 16,https://hdl.handle.net/1887.1/item:1941419,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1941419/manifest
+1369 C 7,https://hdl.handle.net/1887.1/item:1936866,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1936866/manifest
+1496 C 13,https://hdl.handle.net/1887.1/item:1939696,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1939696/manifest
+1497 B 11,https://hdl.handle.net/1887.1/item:1936602,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1936602/manifest
+1497 B 12,https://hdl.handle.net/1887.1/item:1938202,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1938202/manifest
+1497 E 4,https://hdl.handle.net/1887.1/item:1941632,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1941632/manifest
+1497 G 42,https://hdl.handle.net/1887.1/item:1940710,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1940710/manifest
+1497 G 43,https://hdl.handle.net/1887.1/item:1940494,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1940494/manifest
+1498 B 1,https://hdl.handle.net/1887.1/item:1941744,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1941744/manifest
+1498 B 10,https://hdl.handle.net/1887.1/item:1940992,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1940992/manifest
+1498 B 2,https://hdl.handle.net/1887.1/item:1938676,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1938676/manifest
+1498 C 4,https://hdl.handle.net/1887.1/item:1981076,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1981076/manifest
+1498 F 1,https://hdl.handle.net/1887.1/item:1981839,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1981839/manifest
+1407 A 2-3,https://hdl.handle.net/1887.1/item:1987448,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1987448/manifest
+1498 B 11-12,https://hdl.handle.net/1887.1/item:1987449,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1987449/manifest
+1367 B 14: 1,https://hdl.handle.net/1887.1/item:1982012,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1982012/manifest
+1367 B 14: 2,https://hdl.handle.net/1887.1/item:1980929,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1980929/manifest
+1368 D 21: 1,https://hdl.handle.net/1887.1/item:1981273,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1981273/manifest
+1368 D 21: 2,https://hdl.handle.net/1887.1/item:1981068,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1981068/manifest
+1368 D 21: 3,https://hdl.handle.net/1887.1/item:1981820,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1981820/manifest
+1370 E 16: 1,https://hdl.handle.net/1887.1/item:1981739,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1981739/manifest
+1370 E 16: 2,https://hdl.handle.net/1887.1/item:1979734,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1979734/manifest
+BPL 1010,https://hdl.handle.net/1887.1/item:1989383,https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1989383/manifest

--- a/_layouts/manuscript.html
+++ b/_layouts/manuscript.html
@@ -42,12 +42,12 @@ classes: wide
         mir = Mirador({
         id: "viewer",
         buildPath: "https://lab.library.universiteitleiden.nl/mirador/2.7.0/",
-        data: [{manifestUri: "{{ page.manifest }}", location: "Leiden University Library"}],
+        data: [{manifestUri: "{{ this_ms.manifest }}", location: "Leiden University Library"}],
         mainMenuSettings: {
             show: false
         },
         windowObjects: [{
-            loadedManifest: "{{ page.manifest }}",
+            loadedManifest: "{{ this_ms.manifest }}",
             displayLayout: false,
             bottomPanel: false,
             bottomPanelAvailable: false,

--- a/_manuscripts/bpl-1015.md
+++ b/_manuscripts/bpl-1015.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Manners of our forefathers
 shelfmark: BPL 1015
 origin: "France?"

--- a/_manuscripts/bpl-137-d.md
+++ b/_manuscripts/bpl-137-d.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: An Artistic Failure
 shelfmark: BPL 137 D
 origin: "France/Italy"

--- a/_manuscripts/bpl-138.md
+++ b/_manuscripts/bpl-138.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: A medieval book order
 shelfmark: BPL 138
 origin: "France"

--- a/_manuscripts/bpl-139-b.md
+++ b/_manuscripts/bpl-139-b.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Testing the Pen
 shelfmark: BPL 139 B
 origin: "Fleury, France"

--- a/_manuscripts/bpl-154.md
+++ b/_manuscripts/bpl-154.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Applied astronomy
 shelfmark: BPL 154
 origin: "Apennine Peninsula, France"

--- a/_manuscripts/bpl-164.md
+++ b/_manuscripts/bpl-164.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Cases of conscience
 shelfmark: BPL 164
 origin: "Germany?"

--- a/_manuscripts/bpl-17.md
+++ b/_manuscripts/bpl-17.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: A medieval dictionary
 shelfmark: BPL 17
 origin: "France?"

--- a/_manuscripts/bpl-1715.md
+++ b/_manuscripts/bpl-1715.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: More than words
 shelfmark: BPL 1715
 origin: "Apennine Peninsula, Italy"

--- a/_manuscripts/bpl-1765.md
+++ b/_manuscripts/bpl-1765.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Books in the Cradle
 shelfmark: BPL 1765
 origin: "Netherlands?"

--- a/_manuscripts/bpl-1800.md
+++ b/_manuscripts/bpl-1800.md
@@ -2,7 +2,7 @@
 layout: manuscript
 handle: https://hdl.handle.net/1887.1/item:1669863
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Mistake or forgery?
 shelfmark: BPL 1800
 origin: "Netherlands"

--- a/_manuscripts/bpl-186.md
+++ b/_manuscripts/bpl-186.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Advanced grammar
 shelfmark: BPL 186
 origin: "Apennine Peninsula, Italy? and France"

--- a/_manuscripts/bpl-1905.md
+++ b/_manuscripts/bpl-1905.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: The wound man
 shelfmark: BPL 1905
 origin: "Southern Netherlands?, Netherlands"

--- a/_manuscripts/bpl-191-a.md
+++ b/_manuscripts/bpl-191-a.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Face to Face with Statius
 shelfmark: BPL 191 A
 origin: "France/Southern Netherlands"

--- a/_manuscripts/bpl-191-bd.md
+++ b/_manuscripts/bpl-191-bd.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Finger gestures
 shelfmark: BPL 191 BD
 origin: "Germany"

--- a/_manuscripts/bpl-191-e.md
+++ b/_manuscripts/bpl-191-e.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Miscalculation!
 shelfmark: BPL 191 E
 origin: "Germany and Italy"

--- a/_manuscripts/bpl-194.md
+++ b/_manuscripts/bpl-194.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: A helping hand
 shelfmark: BPL 194
 origin: "Germany or Netherlands"

--- a/_manuscripts/bpl-1949.md
+++ b/_manuscripts/bpl-1949.md
@@ -2,7 +2,7 @@
 layout: manuscript
 handle: https://hdl.handle.net/1887.1/item:1667560
 route: religion-devotion
-manifest: "https://transcription.digitalscholarship.nl/iiif/5/manifest"
+
 title: Solitary devotion
 shelfmark: BPL 1949
 origin: "Roermond, Netherlands"

--- a/_manuscripts/bpl-195.md
+++ b/_manuscripts/bpl-195.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: The art of reasoning
 shelfmark: BPL 195
 origin: "France"

--- a/_manuscripts/bpl-1956.md
+++ b/_manuscripts/bpl-1956.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Rules and blessings
 shelfmark: BPL 1956
 origin: "Germany"

--- a/_manuscripts/bpl-197.md
+++ b/_manuscripts/bpl-197.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Medieval encyclopedia
 shelfmark: BPL 197
 origin: "Southern Netherlands?, Netherlands"

--- a/_manuscripts/bpl-2231.md
+++ b/_manuscripts/bpl-2231.md
@@ -2,7 +2,7 @@
 layout: manuscript
 handle: https://hdl.handle.net/1887.1/item:1669105
 route: religion-devotion
-manifest: "https://transcription.digitalscholarship.nl/iiif/5/manifest"
+
 title: Something to talk about
 shelfmark: BPL 2231
 origin: "Netherlands"

--- a/_manuscripts/bpl-225.md
+++ b/_manuscripts/bpl-225.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Myths and constellations
 shelfmark: BPL 225
 origin: "Fleury?, France"

--- a/_manuscripts/bpl-226.md
+++ b/_manuscripts/bpl-226.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Saints and dates
 shelfmark: BPL 226
 origin: "West-Germany, Germany"

--- a/_manuscripts/bpl-2480.md
+++ b/_manuscripts/bpl-2480.md
@@ -2,7 +2,7 @@
 layout: manuscript
 handle: https://hdl.handle.net/1887.1/item:1671012
 route: religion-devotion
-manifest: "https://transcription.digitalscholarship.nl/iiif/5/manifest"
+
 title: Daily excercises
 shelfmark: BPL 2480
 origin: "South-Holland, Netherlands"

--- a/_manuscripts/bpl-2482.md
+++ b/_manuscripts/bpl-2482.md
@@ -2,7 +2,7 @@
 layout: manuscript
 handle: https://hdl.handle.net/1887.1/item:1670753
 route: religion-devotion
-manifest: "https://transcription.digitalscholarship.nl/iiif/5/manifest"
+
 title: "Sermons"
 shelfmark: BPL 2482
 origin: "Netherlands"

--- a/_manuscripts/bpl-2483.md
+++ b/_manuscripts/bpl-2483.md
@@ -2,7 +2,7 @@
 layout: manuscript
 handle: https://hdl.handle.net/1887.1/item:1670422
 route: religion-devotion
-manifest: "https://transcription.digitalscholarship.nl/iiif/5/manifest"
+
 title: Follow the rules
 shelfmark: BPL 2483
 origin: "Germany?"

--- a/_manuscripts/bpl-2627.md
+++ b/_manuscripts/bpl-2627.md
@@ -2,7 +2,7 @@
 layout: manuscript
 handle: https://hdl.handle.net/1887.1/item:848872
 route: religion-devotion
-manifest: "https://transcription.digitalscholarship.nl/iiif/5/manifest"
+
 title: One hundred meditations
 shelfmark: BPL 2627
 origin: "Bruges and South Holland, Netherlands"

--- a/_manuscripts/bpl-2706.md
+++ b/_manuscripts/bpl-2706.md
@@ -2,7 +2,7 @@
 layout: manuscript
 handle: https://hdl.handle.net/1887.1/item:1671155
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Marcus' Book of Hours
 shelfmark: BPL 2706
 origin: "Northern Netherlands, Netherlands"

--- a/_manuscripts/bpl-2782.md
+++ b/_manuscripts/bpl-2782.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Personal favorites
 shelfmark: BPL 2782
 origin: "Holland, Netherlands"

--- a/_manuscripts/bpl-2795.md
+++ b/_manuscripts/bpl-2795.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Recycling manuscripts
 shelfmark: BPL 2795
 origin: "Brabant, Netherlands"

--- a/_manuscripts/bpl-2851.md
+++ b/_manuscripts/bpl-2851.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: For want of a nail
 shelfmark: BPL 2851
 origin: "Germany/Netherlands"

--- a/_manuscripts/bpl-2856.md
+++ b/_manuscripts/bpl-2856.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Psalms and bloodletting
 shelfmark: BPL 2856
 origin: "Den Bosch, Netherlands"

--- a/_manuscripts/bpl-2905.md
+++ b/_manuscripts/bpl-2905.md
@@ -2,7 +2,7 @@
 layout: manuscript
 handle: https://hdl.handle.net/1887.1/item:1669553
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Breviarium
 shelfmark: BPL 2905
 origin: "Den Bosch, Netherlands"

--- a/_manuscripts/bpl-304.md
+++ b/_manuscripts/bpl-304.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: From Catholic to Protestant
 shelfmark: BPL 304
 origin: "Northern Netherlands/Germany"

--- a/_manuscripts/bpl-3094.md
+++ b/_manuscripts/bpl-3094.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: A Surgeon's Manual
 shelfmark: BPL 3094
 origin: "Southern Netherlands, Flanders"

--- a/_manuscripts/bpl-3103.md
+++ b/_manuscripts/bpl-3103.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Medicinal herbs and plants
 shelfmark: BPL 3103
 origin: "South-Germany, Germany"

--- a/_manuscripts/bpl-3284.md
+++ b/_manuscripts/bpl-3284.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Medical recipes and remedies
 shelfmark: BPL 3284
 origin: "Germany"

--- a/_manuscripts/bpl-4.md
+++ b/_manuscripts/bpl-4.md
@@ -2,7 +2,7 @@
 layout: manuscript
 handle: https://hdl.handle.net/1887.1/item:1679348
 route: religion-devotion
-manifest: "https://transcription.digitalscholarship.nl/iiif/5/manifest"
+
 title: "The City of God"
 shelfmark: BPL 4
 origin: "Italy"

--- a/_manuscripts/bpl-43.md
+++ b/_manuscripts/bpl-43.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: A real classic
 shelfmark: BPL 43
 origin: "France?"

--- a/_manuscripts/bpl-91.md
+++ b/_manuscripts/bpl-91.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Honorable Boys
 shelfmark: BPL 91
 origin: "Italy"

--- a/_manuscripts/gro-6.md
+++ b/_manuscripts/gro-6.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Practical rhetorical exercises
 shelfmark: GRO 6
 origin: "Florence, Italy"

--- a/_manuscripts/ltk-169.md
+++ b/_manuscripts/ltk-169.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: A self-help book for a king
 shelfmark: LTK 169
 origin: "West-Flanders, Netherlands"

--- a/_manuscripts/ltk-218.md
+++ b/_manuscripts/ltk-218.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: religion-devotion
-manifest: "https://transcription.digitalscholarship.nl/iiif/5/manifest"
+
 title: Three in One
 shelfmark: LTK 218
 origin: "Holland, Netherlands"

--- a/_manuscripts/ltk-237.md
+++ b/_manuscripts/ltk-237.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Written and printed
 shelfmark: LTK 237
 origin: "Netherlands"

--- a/_manuscripts/ltk-247.md
+++ b/_manuscripts/ltk-247.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Secret language
 shelfmark: LTK 247
 origin: "Purmerend, Netherlands"

--- a/_manuscripts/ltk-263.md
+++ b/_manuscripts/ltk-263.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: One of the 11.000 virgins
 shelfmark: LTK 263
 origin: "Leiden?, Netherlands"

--- a/_manuscripts/ltk-278.md
+++ b/_manuscripts/ltk-278.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Saints and legends
 shelfmark: LTK 278
 origin: "Leiden?, Netherlands"

--- a/_manuscripts/ltk-284.md
+++ b/_manuscripts/ltk-284.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Geert Groote
 shelfmark: LTK 284
 origin: "Utrecht, Netherlands"

--- a/_manuscripts/ltk-287.md
+++ b/_manuscripts/ltk-287.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Religious manual or status symbol?
 shelfmark: LTK 287
 origin: "Delft, Netherlands"

--- a/_manuscripts/ltk-303.md
+++ b/_manuscripts/ltk-303.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: How to suffer with Christ
 shelfmark: LTK 303
 origin: "Tongeren, Southern Netherlands"

--- a/_manuscripts/ltk-304.md
+++ b/_manuscripts/ltk-304.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Preventing Plague through Prayer
 shelfmark: LTK 304
 origin: "Brabant, Netherlands"

--- a/_manuscripts/ltk-316.md
+++ b/_manuscripts/ltk-316.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Jesus in hell
 shelfmark: LTK 316
 origin: "Utrecht?, Netherlands"

--- a/_manuscripts/ltk-318.md
+++ b/_manuscripts/ltk-318.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Memento mori
 shelfmark: LTK 318
 origin: "Gouda, Netherlands"

--- a/_manuscripts/ltk-336.md
+++ b/_manuscripts/ltk-336.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: religion-devotion
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: The white nuns of Leiden
 shelfmark: LTK 336
 origin: "Leiden, Netherlands"

--- a/_manuscripts/per-q-85.md
+++ b/_manuscripts/per-q-85.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: A Modern Example
 shelfmark: PER Q 85
 origin: "Netherlands"

--- a/_manuscripts/sca-1.md
+++ b/_manuscripts/sca-1.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: liberal-arts-education
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: A medieval calculator
 shelfmark: SCA 1
 origin: "France"

--- a/_manuscripts/vcf-11.md
+++ b/_manuscripts/vcf-11.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: A Note on Alchemy
 shelfmark: VCF 11
 origin: "Germany"

--- a/_manuscripts/vcf-12.md
+++ b/_manuscripts/vcf-12.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: The marvelous doctor
 shelfmark: VCF 12
 origin: "Germany"

--- a/_manuscripts/vcf-13.md
+++ b/_manuscripts/vcf-13.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: A royal owner
 shelfmark: VCF 13
 origin: "Germany"

--- a/_manuscripts/vcf-14.md
+++ b/_manuscripts/vcf-14.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Magic and spirits
 shelfmark: VCF 14
 origin: "Germany"

--- a/_manuscripts/vcf-15.md
+++ b/_manuscripts/vcf-15.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: The most precious gift of God
 shelfmark: VCF 15
 origin: "Germany"

--- a/_manuscripts/vcf-16.md
+++ b/_manuscripts/vcf-16.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: A medical pioneer
 shelfmark: VCF 16
 origin: "Germany"

--- a/_manuscripts/vcf-17.md
+++ b/_manuscripts/vcf-17.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Secret symbols
 shelfmark: VCF 17
 origin: "Germany"

--- a/_manuscripts/vcf-18.md
+++ b/_manuscripts/vcf-18.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: A secret recipe
 shelfmark: VCF 18
 origin: "Germany"

--- a/_manuscripts/vcf-20.md
+++ b/_manuscripts/vcf-20.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Beneath the Binding
 shelfmark: VCF 20
 origin: "Germany"

--- a/_manuscripts/vcf-21.md
+++ b/_manuscripts/vcf-21.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Planets, metals and elements
 shelfmark: VCF 21
 origin: "Germany"

--- a/_manuscripts/vcf-22.md
+++ b/_manuscripts/vcf-22.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Changing up the script
 shelfmark: VCF 22
 origin: "Germany"

--- a/_manuscripts/vcf-23.md
+++ b/_manuscripts/vcf-23.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: The secret of secrets
 shelfmark: VCF 23
 origin: "Germany"

--- a/_manuscripts/vcf-6.md
+++ b/_manuscripts/vcf-6.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: The philosopher's stone
 shelfmark: VCF 6
 origin: "Dresden, Germany"

--- a/_manuscripts/vcf-8.md
+++ b/_manuscripts/vcf-8.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: A friendly reminder
 shelfmark: VCF 8
 origin: "Germany"

--- a/_manuscripts/vcq-13.md
+++ b/_manuscripts/vcq-13.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Medicine at the court
 shelfmark: VCQ 13
 origin: "Germany"

--- a/_manuscripts/vcq-37.md
+++ b/_manuscripts/vcq-37.md
@@ -1,7 +1,7 @@
 ---
 layout: manuscript
 route: diy-manuals
-manifest: https://transcription.digitalscholarship.nl/iiif/5/manifest
+
 title: Father and son
 shelfmark: VCQ 37
 origin: "Netherlands?"


### PR DESCRIPTION
Thanks to the UBL IIIF project, the manuscripts digitised in this project now have associated IIIF Manifests. This PR adds the URIs to handles.csv as a new column, from which the template gets it and uses it to instantiate Mirador.

The placeholder URI in each manuscript collection item has been removed to prevent confusion.