### PR TITLE
Make folio references active bookmarks

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,6 +4,7 @@ layout: archive
 
 {{ content }}
 
+<h2>Available routes</h2>
 <ul>
 {% for route in site.routes -%}
 <li><a href="{{ route.url | relative_url }}">{{ route.title }}</a></li>

--- a/_layouts/manuscript.html
+++ b/_layouts/manuscript.html
@@ -37,7 +37,47 @@ classes: wide
     {% bibliography --cited %}
 </section>
 <script type="text/javascript">
+    const re = /[fp]?(\d{3}\**[abrv]?)/g
+    // "f284v-285r (NB f197v-f284r blanco, niet opgenomen)"
+    // "f122v-122*r"
+    // "f122*v-122**r"
+    // "f122**v-122***r"
+    // "f122***v-123r"
+    // "opening05 (incl. f001r)"
+    function createUriIndex(manifestData) {
+        var index = {};
+        for (const canvas of manifestData.jsonLd.sequences[0].canvases) {
+            var label = canvas.label;
+            var uri = canvas["@id"];
+            for (const m of label.matchAll(re)) {
+                index[m[1]] = uri;
+            }
+            index[label] = uri;
+        }
+        return index;
+    }
+    function handleRefClick(clickEvent) {
+        if (clickEvent.target.nodeName.toLowerCase() === "span") {
+            var node = clickEvent.target;
+            var label = node.dataset["fol"];
+            label = /[rvab]$/.test(label) ? label.padStart(4, '0') : label.padStart(3, '0');
+            var canvasUri = findCanvasUriByLabel(label);
+            if (canvasUri) {
+                mirWindow.setCurrentCanvasID(canvasUri);
+                // console.debug('Navigated to ', canvasUri);
+            }
+        }
+    }
+
+    function findCanvasUriByLabel(label) {
+        if (label in uriIndex) {
+            return uriIndex[label];
+        }
+        return null;
+    }
     var mir;
+    var mirWindow;
+    var uriIndex;
     $(function() {
         mir = Mirador({
         id: "viewer",
@@ -52,8 +92,16 @@ classes: wide
             bottomPanel: false,
             bottomPanelAvailable: false,
             bottomPanelVisible: false,
-            sidePanel: false
+            sidePanel: false,
+            id: 'the_window'
         }]
         });
+        mir.eventEmitter.subscribe('windowAdded', (event, data) => {
+            mirWindow = mir.viewer.workspace.windows[0];
+        });
+        mir.eventEmitter.subscribe('manifestReceived', (event, data) => {
+            uriIndex = createUriIndex(data);
+        });
+        document.querySelector('#description').addEventListener('click', handleRefClick);
     });
 </script>

--- a/_manuscripts/bpl-1015.md
+++ b/_manuscripts/bpl-1015.md
@@ -24,7 +24,7 @@ The first thing you see when you open this fourteenth-century manuscript
 are five paper leaves added to the beginning of the book during a
 re-binding process. These pages contain copies of descriptions of the
 manuscript from catalogues and other books from the nineteenth and
-twentieth century. On fol. 1v we can, for example, read a quote from
+twentieth century. On fol. <span data-fol="1v" class="fref">1v</span> we can, for example, read a quote from
 Thomas Wright\'s *Opere angelico* (1857) saying that this volume
 contains vocabularies that illustrate "the condition and manners of our
 forefathers". These types of descriptions can be found in many
@@ -38,7 +38,7 @@ provide an aid for English
 [grammar](https://en.wikipedia.org/wiki/Grammar) students, who often
 struggled to learn Latin due to its different grammar and syntax. The
 *Synonyma* was written with advanced grammar students in mind, who used
-it to look up synonyms for important words (see fol. 14v).
+it to look up synonyms for important words (see fol. <span data-fol="14v" class="fref">14v</span>).
 
 The manuscript is decorated with colored initials as well as two
 pen-flourished initials.[^1] The annotations in the margin were added in

--- a/_manuscripts/bpl-1015.md
+++ b/_manuscripts/bpl-1015.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: Manners of our forefathers
 shelfmark: BPL 1015
+sort_as: BPL 1015
 origin: "France?"
 ms_date: "1300-1400"
 ms_creator: Johannes van Garlandia

--- a/_manuscripts/bpl-137-d.md
+++ b/_manuscripts/bpl-137-d.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: An Artistic Failure
 shelfmark: BPL 137 D
+sort_as: BPL 0137 D
 origin: "France/Italy"
 ms_date: "1150-1200"
 ms_creator: Ovidius

--- a/_manuscripts/bpl-138.md
+++ b/_manuscripts/bpl-138.md
@@ -18,12 +18,12 @@ questions:
 - b12
 ---
 
-The beginning of this manuscript contains an interesting note (fol. 1v).
+The beginning of this manuscript contains an interesting note (fol. <span data-fol="1v" class="fref">1v</span>).
 It describes an order of 800 printed books: 200 booklets with
 penitential psalms, 200 copies of Cato and the "cleene gebeden" (brief
 prayers), and 400 booklets of the most common prayers. The note was
 probably scribbled down by the scribe of the manuscript Jean Brulelou
-(see fol. 165r "Iste liber competit Johanni brulelou"). Brulelou
+(see fol. <span data-fol="165r" class="fref">165r</span> "Iste liber competit Johanni brulelou"). Brulelou
 originally worked as a scribe in Tournai but changed professions in 1470
 when he became a printer in Bruges. The person who ordered the books was
 someone called "Gijs the Perkamentmaker" (Gijs the Parchmentmaker). This

--- a/_manuscripts/bpl-138.md
+++ b/_manuscripts/bpl-138.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: A medieval book order
 shelfmark: BPL 138
+sort_as: BPL 0138
 origin: "France"
 ms_date: "1437"
 ms_title: Disticha Catonis

--- a/_manuscripts/bpl-139-b.md
+++ b/_manuscripts/bpl-139-b.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: Testing the Pen
 shelfmark: BPL 139 B
+sort_as: BPL 0139 B
 origin: "Fleury, France"
 ms_date: "900-1100"
 ms_creator: Abbo van Fleury

--- a/_manuscripts/bpl-139-b.md
+++ b/_manuscripts/bpl-139-b.md
@@ -31,7 +31,7 @@ amongst other texts on logic, the *De syllogisms categoricis,* which was
 written by [Abbo of Fleury](https://en.wikipedia.org/wiki/Abbo_of_Fleury) (c. 945-1004)
 specifically for students of dialectic. The manuscript was copied by the
 Convent of Fleury-St. Benoit in France. Throughout the manuscript we can
-find many diagrams. Fol. 31r contains an
+find many diagrams. Fol. <span data-fol="31r" class="fref">31r</span> contains an
 [anthropomorphic](https://en.wikipedia.org/wiki/Anthropomorphism)
 initial of a man that is being torn by two lions.
 

--- a/_manuscripts/bpl-154.md
+++ b/_manuscripts/bpl-154.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: Applied astronomy
 shelfmark: BPL 154
+sort_as: BPL 0154
 origin: "Apennine Peninsula, France"
 ms_date: "1200-1400"
 ms_creator: Bede

--- a/_manuscripts/bpl-164.md
+++ b/_manuscripts/bpl-164.md
@@ -40,7 +40,7 @@ the full text. Explanations for key words from the main text were
 written in the margin, making it easier for students to find the
 meanings of the words. Even though the manuscript has minimal
 decorations, the illuminator had added one fun element by drawing a
-little face inside in an initial on fol. 17v.[^1]
+little face inside in an initial on fol. 17v[^1].
 
 [^1] [Decorating the Book: Doodles]({{ "/glossary/#doodles" | relative_url }})
 

--- a/_manuscripts/bpl-164.md
+++ b/_manuscripts/bpl-164.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: Cases of conscience
 shelfmark: BPL 164
+sort_as: BPL 0164
 origin: "Germany?"
 ms_date: "1300-1500"
 ms_creator: Astesanus of Asti

--- a/_manuscripts/bpl-164.md
+++ b/_manuscripts/bpl-164.md
@@ -40,7 +40,7 @@ the full text. Explanations for key words from the main text were
 written in the margin, making it easier for students to find the
 meanings of the words. Even though the manuscript has minimal
 decorations, the illuminator had added one fun element by drawing a
-little face inside in an initial on fol. 17v[^1].
+little face inside in an initial on fol. <span data-fol="17v" class="fref">17v</span>[^1].
 
 [^1] [Decorating the Book: Doodles]({{ "/glossary/#doodles" | relative_url }})
 

--- a/_manuscripts/bpl-17.md
+++ b/_manuscripts/bpl-17.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: A medieval dictionary
 shelfmark: BPL 17
+sort_as: BPL 0017
 origin: "France?"
 ms_date: "c. 1200"
 ms_title: Elementarium

--- a/_manuscripts/bpl-17.md
+++ b/_manuscripts/bpl-17.md
@@ -43,7 +43,7 @@ the Latin language.
 Each letter of the alphabet within this manuscript is introduced with a
 pen-flourished or colored initial. Lines that are not fully occupied by
 script are filled in with red decorations, called line fillers (see for
-example fol. 67v).[^1]
+example fol. <span data-fol="67v" class="fref">67v</span>).[^1]
 
 [^1]: [Decorating the Book]({{ "/glossary/#decorating-the-book" | relative_url }})
 

--- a/_manuscripts/bpl-1715.md
+++ b/_manuscripts/bpl-1715.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: More than words
 shelfmark: BPL 1715
+sort_as: BPL 1715
 origin: "Apennine Peninsula, Italy"
 ms_date: "1458"
 ms_creator: Festus

--- a/_manuscripts/bpl-1765.md
+++ b/_manuscripts/bpl-1765.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: Books in the Cradle
 shelfmark: BPL 1765
+sort_as: BPL 1765
 origin: "Netherlands?"
 ms_date: "1400-1450"
 ms_title: Loquagium rhetoricae

--- a/_manuscripts/bpl-1765.md
+++ b/_manuscripts/bpl-1765.md
@@ -33,7 +33,7 @@ could add decorated initials, like what was common practice in the
 production of manuscripts. Both printed parts of this book contain
 pen-flourished initials in the script style of Haarlem (the
 Netherlands). The illuminator has also added red marks next to the
-headings of the first part (see for example fol. 3r), probably as a
+headings of the first part (see for example fol. <span data-fol="3r" class="fref">3r</span>), probably as a
 reference to rubrics.[^1] Although the manuscript part of this book
 contains empty spaces it is not decorated. This means that this part was
 still separate from the two printed books when they texts were

--- a/_manuscripts/bpl-1800.md
+++ b/_manuscripts/bpl-1800.md
@@ -5,6 +5,7 @@ route: religion-devotion
 
 title: Mistake or forgery?
 shelfmark: BPL 1800
+sort_as: BPL 1800
 origin: "Netherlands"
 ms_date: "1459-1530"
 ms_title: Noordnederlandse Historiebijbel 

--- a/_manuscripts/bpl-1800.md
+++ b/_manuscripts/bpl-1800.md
@@ -36,11 +36,11 @@ Maerlant'](https://en.wikipedia.org/wiki/Jacob_van_Maerlant)s
 
 This particular manuscript, which contains numerous rubrics[^1] as well as
 colored initials, consists of two parts. The first part dates to 1530,
-the second part to 1459. From fol. 128 onward this manuscript differs
+the second part to 1459. From fol. <span data-fol="128r" class="fref">128</span> onward this manuscript differs
 from other manuscripts that contain the Second History Bible. It is
 likely that the scribe copied this part of the manuscript from another
 source that was a closer translation of the Vulgate. At the end of the
-text (fol. 245r) the scribe writes *"Et sic est finis MCCC XXII"*,
+text (fol. <span data-fol="245r" class="fref">245r</span>) the scribe writes *"Et sic est finis MCCC XXII"*,
 claiming that he finished this book in 1322. Did he inadvertently copy
 the date from the manuscript he used as his exemplar, or did he write it
 on purpose, hoping to convince people that this manuscript was also from

--- a/_manuscripts/bpl-186.md
+++ b/_manuscripts/bpl-186.md
@@ -34,18 +34,18 @@ students of grammar continued their education by studying Donatus'
 *Institutiones*.
 
 This manuscript contains parts of both advanced grammar books. It starts
-with book seven and eight of the *Institutiones* (fols. 1r - 86v) and
-continues with six pages of the *Ars Maior* (fols. 87r - 90v). Fol. 90v
-through fol. 96v contain two other studies on grammar. The parts of
+with book seven and eight of the *Institutiones* (fols. <span data-fol="1r" class="fref">1r</span> - <span data-fol="86v" class="fref">86v</span>) and
+continues with six pages of the *Ars Maior* (fols. <span data-fol="87r" class="fref">87r</span> - <span data-fol="90v" class="fref">90v</span>). Fol. <span data-fol="90v" class="fref">90v</span>
+through fol. <span data-fol="96v" class="fref">96v</span> contain two other studies on grammar. The parts of
 this manuscript were bound together on a later date, resulting in a
 strong difference between the lay-outs of each part. The beginning of
 this manuscript of the *Institutiones* contains glosses[^1] from the
 fifteenth or sixteenth century, both in the margin and between the
-lines. The same hand has added even more commentary on fol. 86v. Glosses
+lines. The same hand has added even more commentary on fol. <span data-fol="86v" class="fref">86v</span>. Glosses
 are not the only things written in the margin. Throughout the manuscript
 you can find drawings, doodles and pen trials made by the reader(s). For
-example, notice an alphabet and a couple of ducks or birds on fol. 47v
-and a flower on fol. 12v.
+example, notice an alphabet and a couple of ducks or birds on fol. <span data-fol="47v" class="fref">47v</span>
+and a flower on fol. <span data-fol="12v" class="fref">12v</span>.
 
 [^1]: [Using the Book: Gloss]({{ "/glossary/#gloss" | relative_url }})
 

--- a/_manuscripts/bpl-186.md
+++ b/_manuscripts/bpl-186.md
@@ -34,9 +34,9 @@ students of grammar continued their education by studying Donatus'
 *Institutiones*.
 
 This manuscript contains parts of both advanced grammar books. It starts
-with book seven and eight of the *Institutiones* (fol. 1r - 86v) and
-continues with six pages of the *Ars Maior* (fol. 87r - fol. 90v). Fol.
-90v through fol. 96v. contain two other studies on grammar. The parts of
+with book seven and eight of the *Institutiones* (fols. 1r - 86v) and
+continues with six pages of the *Ars Maior* (fols. 87r - 90v). Fol. 90v
+through fol. 96v contain two other studies on grammar. The parts of
 this manuscript were bound together on a later date, resulting in a
 strong difference between the lay-outs of each part. The beginning of
 this manuscript of the *Institutiones* contains glosses[^1] from the

--- a/_manuscripts/bpl-186.md
+++ b/_manuscripts/bpl-186.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: Advanced grammar
 shelfmark: BPL 186
+sort_as: BPL 0186
 origin: "Apennine Peninsula, Italy? and France"
 ms_date: "1100-1300"
 ms_creator: Priscian

--- a/_manuscripts/bpl-1905.md
+++ b/_manuscripts/bpl-1905.md
@@ -30,13 +30,13 @@ editions. The illustrations in this manuscript are quite rough in
 comparison to the woodcuts in the printed versions, but they are still
 recognizable.
 
-The illustration on fol. 9r depicts the body of a stoic looking figure
+The illustration on fol. <span data-fol="9r" class="fref">9r</span> depicts the body of a stoic looking figure
 covered with cuts and bruises inflicted by knives, daggers and arrows.
 This figure was known as a "[wound
 man](https://en.wikipedia.org/wiki/Wound_Man)". Treatments for these
 various injuries are described in the margin of the page. Other
 illustrations in this manuscript depict which veins could be used for
-blood-letting (fol. 3v), how to find cures for various diseases (fol. 12v), and how to interpret the color of urine (fol. 1v). The scribe of
+blood-letting (fol. <span data-fol="3v" class="fref">3v</span>), how to find cures for various diseases (fol. <span data-fol="12v" class="fref">12v</span>), and how to interpret the color of urine (fol. <span data-fol="1v" class="fref">1v</span>). The scribe of
 this manuscript was apparently quite interested in that last topic, as
 he also added one Latin and two Dutch treatises on urinalysis.
 

--- a/_manuscripts/bpl-1905.md
+++ b/_manuscripts/bpl-1905.md
@@ -36,8 +36,7 @@ This figure was known as a "[wound
 man](https://en.wikipedia.org/wiki/Wound_Man)". Treatments for these
 various injuries are described in the margin of the page. Other
 illustrations in this manuscript depict which veins could be used for
-blood-letting (fol. 3v), how to find cures for various diseases (fol.
-12v), and how to interpret the color of urine (fol. 1v). The scribe of
+blood-letting (fol. 3v), how to find cures for various diseases (fol. 12v), and how to interpret the color of urine (fol. 1v). The scribe of
 this manuscript was apparently quite interested in that last topic, as
 he also added one Latin and two Dutch treatises on urinalysis.
 

--- a/_manuscripts/bpl-1905.md
+++ b/_manuscripts/bpl-1905.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: The wound man
 shelfmark: BPL 1905
+sort_as: BPL 1905
 origin: "Southern Netherlands?, Netherlands"
 ms_date: "1400-1600"
 ms_creator: Johannes de Ketham

--- a/_manuscripts/bpl-191-a.md
+++ b/_manuscripts/bpl-191-a.md
@@ -30,7 +30,7 @@ never finished.
 
 This composite manuscript consists of eight parts. As the leaves of the
 parts were being trimmed to the same size, the commentary of the first
-part (fol. 1r - fol. 36v) was partly cut off. As a result, only the
+part (fols. 1r - 36v) was partly cut off. As a result, only the
 first lines of the commentary are still visible. In the early fifteenth
 century the complete manuscript belonged to the Convent of St. James in
 Liege. They already owned the seventh part, containing a commentary on

--- a/_manuscripts/bpl-191-a.md
+++ b/_manuscripts/bpl-191-a.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: Face to Face with Statius
 shelfmark: BPL 191 A
+sort_as: BPL 0191 A
 origin: "France/Southern Netherlands"
 ms_date: "1100-1400"
 ms_creator: John of God

--- a/_manuscripts/bpl-191-a.md
+++ b/_manuscripts/bpl-191-a.md
@@ -23,14 +23,14 @@ questions:
 Have you ever wondered what a classical author looked like? Someone,
 either the scribe or a future reader, tried to illustrate this by
 drawing a portrait of [Statius](https://en.wikipedia.org/wiki/Statius)
-on fol. 213v. Unfortunately, his or her artistic skills leave much to be
+on fol. <span data-fol="213v" class="fref">213v</span>. Unfortunately, his or her artistic skills leave much to be
 desired - Statius' only recognizable trait is his laurel wreath. The
-same "artist" tried to draw another portrait on fol. 238v, but it was
+same "artist" tried to draw another portrait on fol. <span data-fol="238v" class="fref">238v</span>, but it was
 never finished.
 
 This composite manuscript consists of eight parts. As the leaves of the
 parts were being trimmed to the same size, the commentary of the first
-part (fols. 1r - 36v) was partly cut off. As a result, only the
+part (fols. <span data-fol="1r" class="fref">1r</span> - <span data-fol="36v" class="fref">36v</span>) was partly cut off. As a result, only the
 first lines of the commentary are still visible. In the early fifteenth
 century the complete manuscript belonged to the Convent of St. James in
 Liege. They already owned the seventh part, containing a commentary on

--- a/_manuscripts/bpl-191-bd.md
+++ b/_manuscripts/bpl-191-bd.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: Finger gestures
 shelfmark: BPL 191 BD
+sort_as: BPL 0191 BD
 origin: "Germany"
 ms_date: "1100-1150"
 ms_creator: Hrabanus Maurus

--- a/_manuscripts/bpl-191-bd.md
+++ b/_manuscripts/bpl-191-bd.md
@@ -25,7 +25,7 @@ aided by the calculators on their cellphones. However, during the Middle
 Ages finger counting was used by even the most experienced
 mathematicians. People were able to count to a thousand, just by using
 their two hands. The numbers 1-99 were counted on the left hand, while
-the numbers 100-9999 were counted on the right. Fol. 4r in this
+the numbers 100-9999 were counted on the right. Fol. <span data-fol="4r" class="fref">4r</span> in this
 manuscript depicts an illustration of how to count on your fingers
 according to the method used at the time.
 

--- a/_manuscripts/bpl-191-e.md
+++ b/_manuscripts/bpl-191-e.md
@@ -35,7 +35,7 @@ It also contains excerpts on grammar and astronomy, glosses on the
 Bible, and letters from [Ivo of Chartres](https://en.wikipedia.org/wiki/Ivo_of_Chartres). The different
 texts were bound together some time later, resulting in a variety of
 lay-outs throughout the manuscript. In the margins of the first part of
-this manuscript (fols. 1r - 60v) you can see unusual marks, known as
+this manuscript (fols. <span data-fol="1r" class="fref">1r</span> - <span data-fol="60v" class="fref">60v</span>) you can see unusual marks, known as
 *nota bene*[^1] markings, on almost every leaf. If you look closely you
 can see that each drawing is a monogram of the letters n, o, t, and a.
 Nota bene markings vary in appearance from page to page.

--- a/_manuscripts/bpl-191-e.md
+++ b/_manuscripts/bpl-191-e.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: Miscalculation!
 shelfmark: BPL 191 E
+sort_as: BPL 0191 E
 origin: "Germany and Italy"
 ms_date: "1100-1200"
 ms_creator: Reinherus

--- a/_manuscripts/bpl-191-e.md
+++ b/_manuscripts/bpl-191-e.md
@@ -35,7 +35,7 @@ It also contains excerpts on grammar and astronomy, glosses on the
 Bible, and letters from [Ivo of Chartres](https://en.wikipedia.org/wiki/Ivo_of_Chartres). The different
 texts were bound together some time later, resulting in a variety of
 lay-outs throughout the manuscript. In the margins of the first part of
-this manuscript (fol. 1r - fol. 60v) you can see unusual marks, known as
+this manuscript (fols. 1r - 60v) you can see unusual marks, known as
 *nota bene*[^1] markings, on almost every leaf. If you look closely you
 can see that each drawing is a monogram of the letters n, o, t, and a.
 Nota bene markings vary in appearance from page to page.

--- a/_manuscripts/bpl-194.md
+++ b/_manuscripts/bpl-194.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: A helping hand
 shelfmark: BPL 194
+sort_as: BPL 0194
 origin: "Germany or Netherlands"
 ms_date: "1000-1100"
 ms_creator: Guido of Arezzo

--- a/_manuscripts/bpl-194.md
+++ b/_manuscripts/bpl-194.md
@@ -25,7 +25,7 @@ and the *Dialogus*. Arezzo (c. 991- c. 1033) was an Italian monk and
 music theorist. He is credited with the invention of the use of staff
 lines to annotate music. Arezzo is also famous for "[The Guidonian Hand](https://en.wikipedia.org/wiki/Guidonian_hand)", a mnemonic system
 that teaches how to sing from sight. An example of a Guidonian Hand can
-be found in Fol. 1r of this manuscript. Once a singer was familiar with
+be found in Fol. <span data-fol="1r" class="fref">1r</span> of this manuscript. Once a singer was familiar with
 the Guidonian Hand system he could easily sing notes that corresponded
 to whichever part of the hand the music teacher pointed to. There are
 several other tools throughout the manuscript, including diagrams that

--- a/_manuscripts/bpl-1949.md
+++ b/_manuscripts/bpl-1949.md
@@ -22,7 +22,7 @@ questions:
 This manuscript, which contains various religious texts written in
 Latin, was formerly owned by the Monastery of the Virgin of Bethlehem in
 Roermond, Netherlands. The monastery belonged to the
-[Carthusians](https://en.wikipedia.org/wiki/Carthusians) (see fol. 1r),
+[Carthusians](https://en.wikipedia.org/wiki/Carthusians) (see fol. <span data-fol="1r" class="fref">1r</span>),
 a particularly strict religious order of Western Europe. Although
 Carthusian monks lived together communally in the monastery, called a
 "charterhouse", they spent most of their time in the solitude of their
@@ -36,12 +36,12 @@ Bethlehem was the most important library in the Roermond area.
 
 The pages of this manuscript contain rubrics and are decorated with
 colored initials. Most of the manuscript's quires contain paper leaves,
-though some are made from parchment.[^1] On both fol. 42v and fol. 43r we
+though some are made from parchment.[^1] On both fol. <span data-fol="42v" class="fref">42v</span> and fol. <span data-fol="43r" class="fref">43r</span> we
 find a poem with an interesting layout. Instead of writing the rhyming
 letters at the end of each individual line the scribe has written the
 rhyming parts only once and connected them to the corresponding
 sentences with braces. The last sentence of the text has been crossed
-out with red ink (see fol. 163r).
+out with red ink (see fol. <span data-fol="163r" class="fref">163r</span>).
 
 [^1]: [Choosing a writing support]({{ "/glossary/#choosing-a-writing-support" | relative_url }})
 

--- a/_manuscripts/bpl-1949.md
+++ b/_manuscripts/bpl-1949.md
@@ -5,6 +5,7 @@ route: religion-devotion
 
 title: Solitary devotion
 shelfmark: BPL 1949
+sort_as: BPL 1949
 origin: "Roermond, Netherlands"
 ms_date: "1450-1500"
 ms_title: Devotae Allocutiones 

--- a/_manuscripts/bpl-195.md
+++ b/_manuscripts/bpl-195.md
@@ -34,8 +34,8 @@ glosses[^1] in the margin and between the lines. Most of the commentary in
 the margin is lost because the leaves were trimmed when the manuscript
 was rebound. The annotations in the second part, containing the *De
 inventione,* were written by several people. One reader has marked
-important passages on fol. 44v and fol. 48v by drawing little hands
-(*maniculae*, see also BPL 197). The last leaf of the manuscript, fol. 88, contains various scribbles and was probably used to test the pen of
+important passages on fol. <span data-fol="44v" class="fref">44v</span> and fol. <span data-fol="48v" class="fref">48v</span> by drawing little hands
+(*maniculae*, see also BPL 197). The last leaf of the manuscript, fol. <span data-fol="88r" class="fref">88</span>, contains various scribbles and was probably used to test the pen of
 the scribe (see also BPL 139 B).
 
 [^1]: [Using the Book: Gloss]({{ "/glossary/#gloss" | relative_url }})

--- a/_manuscripts/bpl-195.md
+++ b/_manuscripts/bpl-195.md
@@ -35,8 +35,7 @@ the margin is lost because the leaves were trimmed when the manuscript
 was rebound. The annotations in the second part, containing the *De
 inventione,* were written by several people. One reader has marked
 important passages on fol. 44v and fol. 48v by drawing little hands
-(*maniculae*, see also BPL 197). The last leaf of the manuscript, fol.
-88, contains various scribbles and was probably used to test the pen of
+(*maniculae*, see also BPL 197). The last leaf of the manuscript, fol. 88, contains various scribbles and was probably used to test the pen of
 the scribe (see also BPL 139 B).
 
 [^1]: [Using the Book: Gloss]({{ "/glossary/#gloss" | relative_url }})

--- a/_manuscripts/bpl-195.md
+++ b/_manuscripts/bpl-195.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: The art of reasoning
 shelfmark: BPL 195
+sort_as: BPL 0195
 origin: "France"
 ms_date: "1100-1200"
 ms_title: Rhetorica ad Herennium

--- a/_manuscripts/bpl-1956.md
+++ b/_manuscripts/bpl-1956.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: Rules and blessings
 shelfmark: BPL 1956
+sort_as: BPL 1956
 origin: "Germany"
 ms_date: "1507"
 ms_title: S. Augustini regula

--- a/_manuscripts/bpl-1956.md
+++ b/_manuscripts/bpl-1956.md
@@ -20,7 +20,7 @@ questions:
 ---
 
 This manuscript was in the possession of the Abbey of Arnstein in
-Germany (see fol. 60v), whose members belonged to the order of the
+Germany (see fol. <span data-fol="60v" class="fref">60v</span>), whose members belonged to the order of the
 [Norbertines](https://en.wikipedia.org/wiki/Premonstratensians). The
 Norbertines adhered to the [Rule of St.
 Augustine](https://nl.wikipedia.org/wiki/Augustijnen_(kloosterorde))
@@ -36,7 +36,7 @@ the spring equinox. The scribe usually wrote down the year in which he
 finished copying the manuscript in the
 [computus](https://en.wikipedia.org/wiki/Computus) circle, helping
 modern readers determine the date of production. The computus circle on
-fol. 60v in this manuscript reads "M.V. hundert und vii", which tells us
+fol. <span data-fol="60v" class="fref">60v</span> in this manuscript reads "M.V. hundert und vii", which tells us
 it was created in 1507. Even though the main texts in this manuscript
 are written in Dutch, the rubrics are written in German. There are parts
 of the text that were meant to be sung. These parts are written on

--- a/_manuscripts/bpl-197.md
+++ b/_manuscripts/bpl-197.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: Medieval encyclopedia
 shelfmark: BPL 197
+sort_as: BPL 0197
 origin: "Southern Netherlands?, Netherlands"
 ms_date: "1100-1300"
 ms_creator: Isidore of Seville

--- a/_manuscripts/bpl-197.md
+++ b/_manuscripts/bpl-197.md
@@ -35,8 +35,8 @@ minerals and stones.
 
 This manuscript consists of three independent parts that were bound
 together on a later date. The first part was owned in the fifteenth
-century by Johannes de Soumaing (see fol. 34v). On almost every leaf of
-the second part (fols. 35r - 68v) you can see drawings of little hands in
+century by Johannes de Soumaing (see fol. <span data-fol="34v" class="fref">34v</span>). On almost every leaf of
+the second part (fols. <span data-fol="35r" class="fref">35r</span> - <span data-fol="68v" class="fref">68v</span>) you can see drawings of little hands in
 the margin that are pointing to sentences in the text. These hands,
 called "manicula"[^1], show the reader which passages deserve extra
 attention. The shape of the hands varies, suggesting that they were

--- a/_manuscripts/bpl-197.md
+++ b/_manuscripts/bpl-197.md
@@ -36,7 +36,7 @@ minerals and stones.
 This manuscript consists of three independent parts that were bound
 together on a later date. The first part was owned in the fifteenth
 century by Johannes de Soumaing (see fol. 34v). On almost every leaf of
-the second part (fol. 35r-68v) you can see drawings of little hands in
+the second part (fols. 35r - 68v) you can see drawings of little hands in
 the margin that are pointing to sentences in the text. These hands,
 called "manicula"[^1], show the reader which passages deserve extra
 attention. The shape of the hands varies, suggesting that they were

--- a/_manuscripts/bpl-2231.md
+++ b/_manuscripts/bpl-2231.md
@@ -33,14 +33,14 @@ and confession. Material (inspiration) for his collatieboeken came from
 the Bible, [patristic](https://en.wikipedia.org/wiki/Patristics)
 writings, and his own publications, and included a table of contents so
 that the Brethren of the Common Life could easily look up the various
-subjects (see fol. 3v).
+subjects (see fol. <span data-fol="3v" class="fref">3v</span>).
 
 The only collatieboeken of Dirc van Herxen that has survived fully
 intact is held by the University Library of Utrecht (UB 3 L 6). This
 manuscript from Leiden (BPL 2231) is comprised of the second half of the
 first book of *collationes*, containing *Die Materie van den Sonden* (On
 the Topic of Sins). It belonged to the Convent of the Virgin in
-Gaesdonck (the Netherlands) in the fifteenth century (see fol. 3v, as
+Gaesdonck (the Netherlands) in the fifteenth century (see fol. <span data-fol="3v" class="fref">3v</span>, as
 well as BPL 2482 and BPL 2483).
 
 The manuscript has very few decorations and the parchment is damaged on

--- a/_manuscripts/bpl-2231.md
+++ b/_manuscripts/bpl-2231.md
@@ -5,6 +5,7 @@ route: religion-devotion
 
 title: Something to talk about
 shelfmark: BPL 2231
+sort_as: BPL 2231
 origin: "Netherlands"
 ms_date: "1450-1500"
 ms_creator: Dirc van Herxen

--- a/_manuscripts/bpl-225.md
+++ b/_manuscripts/bpl-225.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: Myths and constellations
 shelfmark: BPL 225
+sort_as: BPL 0225
 origin: "Fleury?, France"
 ms_date: "1100-1200"
 ms_creator: Hyginus

--- a/_manuscripts/bpl-226.md
+++ b/_manuscripts/bpl-226.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: Saints and dates
 shelfmark: BPL 226
+sort_as: BPL 0226
 origin: "West-Germany, Germany"
 ms_date: "1100-1200"
 ms_creator: Helpericus

--- a/_manuscripts/bpl-226.md
+++ b/_manuscripts/bpl-226.md
@@ -29,7 +29,7 @@ after the first full moon of spring. (see BPL 154). This manuscript,
 which belonged to the Convent of St. Pantaleon in Cologne, contains
 three texts that are closely connected to the Liturgical Year. The first
 part of this manuscript contains [Helpericus van Auxerre's](https://de.wikipedia.org/wiki/Helperic_von_Auxerre) *De computo.* The [*computus*](https://en.wikipedia.org/wiki/Computus)
-circles on fol. 32v could be used to determine the correct date of
+circles on fol. <span data-fol="32v" class="fref">32v</span> could be used to determine the correct date of
 Easter. The second part, a
 [martyrology](https://en.wikipedia.org/wiki/Roman_Martyrology), is a
 list of the feast days of martyrs and saints. Lastly, this manuscript
@@ -41,7 +41,7 @@ used recycled pages from a twelfth-century text on grammar to create the
 flyleaves[^1], in addition to using an antiphonary from the sixteenth
 century for the cover. The cover was separated from the manuscript and
 now has its own shelfmark (BPL 2515: 40). At some point the leaves of
-fol. 37 and fol. 38 were extended by sewing on pieces of parchment.
+fol. <span data-fol="37r" class="fref">37</span> and fol. <span data-fol="38r" class="fref">38</span> were extended by sewing on pieces of parchment.
 These page extensions are quite noticeable because the binder did not
 cut the leaves to a uniform size.
 

--- a/_manuscripts/bpl-2480.md
+++ b/_manuscripts/bpl-2480.md
@@ -32,17 +32,17 @@ This prayer book encourages contemplation on various subjects depending
 on the day of the week. For example, on Sundays Alijt would have
 contemplated eternal joy and happiness in heaven. On Mondays, however,
 Alijt was urged to contemplate death which would, according to this
-exercise (see fols. 1v - 8v), help her to refrain from sin. Following the
-daily meditations (from fol. 52v and beyond) this book contains prayers
+exercise (see fols. <span data-fol="1v" class="fref">1v</span> - <span data-fol="8v" class="fref">8v</span>), help her to refrain from sin. Following the
+daily meditations (from fol. <span data-fol="52v" class="fref">52v</span> and beyond) this book contains prayers
 for various other occasions.
 
 We know that the scribe who copied this prayer book was named Aernt
-Janszoon, from the city of Oudewater, because in fol. 91v he wrote
+Janszoon, from the city of Oudewater, because in fol. <span data-fol="91v" class="fref">91v</span> he wrote
 *"Bidt voer broeder aernt jans soen van oudewater om goods willen"*
 (Please pray for friar Aernt Janszoon of Oudewater for God's sake).[^1] In
 contrast to a highly decorated [book of hours](https://en.wikipedia.org/wiki/Book_of_hours), this manuscript is
 simply and sparsely decorated. Each exercise starts with a
-pen-flourished initial, but otherwise only the first page (see fol. 2r)
+pen-flourished initial, but otherwise only the first page (see fol. <span data-fol="2r" class="fref">2r</span>)
 has elaborate decoration. The scribe has added so-called *cadels,*
 extensions of the ascending and descending strokes of the letters, on
 the first letter of the first line of every page.

--- a/_manuscripts/bpl-2480.md
+++ b/_manuscripts/bpl-2480.md
@@ -5,6 +5,7 @@ route: religion-devotion
 
 title: Daily excercises
 shelfmark: BPL 2480
+sort_as: BPL 2480
 origin: "South-Holland, Netherlands"
 ms_date: "1528"
 ms_title: Gebedenboek 

--- a/_manuscripts/bpl-2480.md
+++ b/_manuscripts/bpl-2480.md
@@ -32,7 +32,7 @@ This prayer book encourages contemplation on various subjects depending
 on the day of the week. For example, on Sundays Alijt would have
 contemplated eternal joy and happiness in heaven. On Mondays, however,
 Alijt was urged to contemplate death which would, according to this
-exercise (see fols. 1v-8v), help her to refrain from sin. Following the
+exercise (see fols. 1v - 8v), help her to refrain from sin. Following the
 daily meditations (from fol. 52v and beyond) this book contains prayers
 for various other occasions.
 
@@ -42,7 +42,7 @@ Janszoon, from the city of Oudewater, because in fol. 91v he wrote
 (Please pray for friar Aernt Janszoon of Oudewater for God's sake).[^1] In
 contrast to a highly decorated [book of hours](https://en.wikipedia.org/wiki/Book_of_hours), this manuscript is
 simply and sparsely decorated. Each exercise starts with a
-pen-flourished initial, but otherwise only the first page (see fol. 2r.)
+pen-flourished initial, but otherwise only the first page (see fol. 2r)
 has elaborate decoration. The scribe has added so-called *cadels,*
 extensions of the ascending and descending strokes of the letters, on
 the first letter of the first line of every page.

--- a/_manuscripts/bpl-2482.md
+++ b/_manuscripts/bpl-2482.md
@@ -5,6 +5,7 @@ route: religion-devotion
 
 title: "Sermons"
 shelfmark: BPL 2482
+sort_as: BPL 2482
 origin: "Netherlands"
 ms_date: "1400-1425"
 ms_title: Sermones de tempore et de sanctis

--- a/_manuscripts/bpl-2483.md
+++ b/_manuscripts/bpl-2483.md
@@ -5,6 +5,7 @@ route: religion-devotion
 
 title: Follow the rules
 shelfmark: BPL 2483
+sort_as: BPL 2483
 origin: "Germany?"
 ms_date: "1400-1500"
 ms_title: Regula Benidicti 

--- a/_manuscripts/bpl-2627.md
+++ b/_manuscripts/bpl-2627.md
@@ -40,8 +40,8 @@ psalms, and prayers.
 The two parts of this manuscript were bound together in the sixteenth
 century. Around that time the manuscript belonged the Convent of St.
 Bernard in Antwerp, Belgium (see the note of administrator Livinius de
-Smedt at fol. 1r). The manuscript is beautifully decorated with painted
-initials. Fol. 14r contains a historiated initial[^1] of two angels who
+Smedt at fol. <span data-fol="1r" class="fref">1r</span>). The manuscript is beautifully decorated with painted
+initials. Fol. <span data-fol="14r" class="fref">14r</span> contains a historiated initial[^1] of two angels who
 cover Christ with a blanket. In the lower margin the scribe has added
 catchwords (the first word of the new quire) which made it easier for
 the binder to put the quires in the right order. In the second part of

--- a/_manuscripts/bpl-2627.md
+++ b/_manuscripts/bpl-2627.md
@@ -5,6 +5,7 @@ route: religion-devotion
 
 title: One hundred meditations
 shelfmark: BPL 2627
+sort_as: BPL 2627
 origin: "Bruges and South Holland, Netherlands"
 ms_date: "1400 and 1450-1475"
 ms_creator: Henricus Suso

--- a/_manuscripts/bpl-2706.md
+++ b/_manuscripts/bpl-2706.md
@@ -42,7 +42,7 @@ this manuscript is a Dutch translation of an excerpt from [Henricus
 Suso's](https://en.wikipedia.org/wiki/Henry_Suso) *Horologium aeternae sapientiae* (The Clock of Wisdom).
 
 This manuscript is beautifully decorated with pen-flourished initials.
-Fols. 12v-13r show three
+Fols. 12v - 13r show three
 [computus](https://en.wikipedia.org/wiki/Computus) circles used to
 determine the date of Easter. The text in the circle in fol. 12v asks
 the reader to start looking for the Golden Number from "drientsestig"

--- a/_manuscripts/bpl-2706.md
+++ b/_manuscripts/bpl-2706.md
@@ -42,9 +42,9 @@ this manuscript is a Dutch translation of an excerpt from [Henricus
 Suso's](https://en.wikipedia.org/wiki/Henry_Suso) *Horologium aeternae sapientiae* (The Clock of Wisdom).
 
 This manuscript is beautifully decorated with pen-flourished initials.
-Fols. 12v - 13r show three
+Fols. <span data-fol="12v" class="fref">12v</span> - <span data-fol="13r" class="fref">13r</span> show three
 [computus](https://en.wikipedia.org/wiki/Computus) circles used to
-determine the date of Easter. The text in the circle in fol. 12v asks
+determine the date of Easter. The text in the circle in fol. <span data-fol="12v" class="fref">12v</span> asks
 the reader to start looking for the Golden Number from "drientsestig"
 (sixty-three), which tells us that the manuscript was written in 1463.
 

--- a/_manuscripts/bpl-2706.md
+++ b/_manuscripts/bpl-2706.md
@@ -5,6 +5,7 @@ route: religion-devotion
 
 title: Marcus' Book of Hours
 shelfmark: BPL 2706
+sort_as: BPL 2706
 origin: "Northern Netherlands, Netherlands"
 ms_date: "1463?"
 ms_title: Getijdenboek

--- a/_manuscripts/bpl-2782.md
+++ b/_manuscripts/bpl-2782.md
@@ -30,7 +30,7 @@ Jesus such as his childhood, his entry into Jerusalem, his Crucifixion
 and his Resurrection. The same poems occur in another manuscript owned
 by Johannes Philipszoon from 1472-1481. After Johannes' death in 1509
 the manuscript was given to his daughter, Margriete Claesdochter (see
-fol. 1v).
+fol. <span data-fol="1v" class="fref">1v</span>).
 
 The manuscript is extensively decorated with pen-flourished initials,
 painted borders and colored initials in red and blue. In the front of
@@ -39,7 +39,7 @@ because of water damage. Surprisingly, the red ink was not affected. The
 manuscript begins with a calendar of saints. Just as in BPL 2706, this
 manuscript has [computus](https://en.wikipedia.org/wiki/Computus)
 circles to determine the date of Easter. The starting date is 1481 (see
-fol. 10v).
+fol. <span data-fol="10v" class="fref">10v</span>).
 
 [^1]: [Using the Book]({{ "/glossary/#using-the-book" | relative_url }})
 

--- a/_manuscripts/bpl-2782.md
+++ b/_manuscripts/bpl-2782.md
@@ -4,6 +4,7 @@ route: religion-devotion
 
 title: Personal favorites
 shelfmark: BPL 2782
+sort_as: BPL 2782
 origin: "Holland, Netherlands"
 ms_date: "1481"
 ms_title: Getijdenboek met devotionele teksten

--- a/_manuscripts/bpl-2795.md
+++ b/_manuscripts/bpl-2795.md
@@ -4,6 +4,7 @@ route: religion-devotion
 
 title: Recycling manuscripts
 shelfmark: BPL 2795
+sort_as: BPL 2795
 origin: "Brabant, Netherlands"
 ms_date: "1525-1550"
 ms_title: Rituale

--- a/_manuscripts/bpl-2795.md
+++ b/_manuscripts/bpl-2795.md
@@ -33,8 +33,7 @@ follower of Francis of Assisi and the foundress of the female
 counterpart of the Franciscan order, had written the rules herself in
 the thirteenth century. They are the first known monastic guidelines
 written by a woman. The scribe of this manuscript was also a woman;
-Sister Marijken Breakmans was her name. She has added a colophon in fol.
-97v asking the reader to pray for her soul. Someone has added pieces of
+Sister Marijken Breakmans was her name. She has added a colophon in fol. 97v asking the reader to pray for her soul. Someone has added pieces of
 paper with corrections[^2] or additions to the text on a later date (see
 for example fol. 91r). This manuscript also contains [gothic music
 notation](https://en.wikipedia.org/wiki/Medieval_music).

--- a/_manuscripts/bpl-2795.md
+++ b/_manuscripts/bpl-2795.md
@@ -33,9 +33,9 @@ follower of Francis of Assisi and the foundress of the female
 counterpart of the Franciscan order, had written the rules herself in
 the thirteenth century. They are the first known monastic guidelines
 written by a woman. The scribe of this manuscript was also a woman;
-Sister Marijken Breakmans was her name. She has added a colophon in fol. 97v asking the reader to pray for her soul. Someone has added pieces of
+Sister Marijken Breakmans was her name. She has added a colophon in fol. <span data-fol="97v" class="fref">97v</span> asking the reader to pray for her soul. Someone has added pieces of
 paper with corrections[^2] or additions to the text on a later date (see
-for example fol. 91r). This manuscript also contains [gothic music
+for example fol. <span data-fol="91r" class="fref">91r</span>). This manuscript also contains [gothic music
 notation](https://en.wikipedia.org/wiki/Medieval_music).
 
 [^1]: [Choosing a Writing Support: Parchment Palimpsest]({{ "/glossary/#parchment-palimpsest" | relative_url }})

--- a/_manuscripts/bpl-2851.md
+++ b/_manuscripts/bpl-2851.md
@@ -4,6 +4,7 @@ route: religion-devotion
 
 title: For want of a nail
 shelfmark: BPL 2851
+sort_as: BPL 2851
 origin: "Germany/Netherlands"
 ms_date: "1450-1475"
 ms_title: Processionale

--- a/_manuscripts/bpl-2856.md
+++ b/_manuscripts/bpl-2856.md
@@ -26,7 +26,7 @@ practice themselves, without the help of a doctor. People believed that
 bloodletting could help against various ailments and could encourage
 spiritual asceticism. Considering this, it is not so surprising that
 this fifteenth century Psalter contains a table for favorable
-bloodletting times and locations (see fol. 7r - fol. 12v.).
+bloodletting times and locations (see fols. 7r - 12v).
 Additionally, it contains a calendar to calculate the dates of Easter,
 the Book of Psalms from the Bible, and a description of the translation
 of St. Catharina. The texts are written in both Dutch and Latin.

--- a/_manuscripts/bpl-2856.md
+++ b/_manuscripts/bpl-2856.md
@@ -26,17 +26,17 @@ practice themselves, without the help of a doctor. People believed that
 bloodletting could help against various ailments and could encourage
 spiritual asceticism. Considering this, it is not so surprising that
 this fifteenth century Psalter contains a table for favorable
-bloodletting times and locations (see fols. 7r - 12v).
+bloodletting times and locations (see fols. <span class="fref" data-fol="7r">7r</span> - <span data-fol="12v" class="fref">12v</span>).
 Additionally, it contains a calendar to calculate the dates of Easter,
 the Book of Psalms from the Bible, and a description of the translation
 of St. Catharina. The texts are written in both Dutch and Latin.
 
-The pen-flourished initials[^1] of this manuscript (see fol. 14) are
+The pen-flourished initials[^1] of this manuscript (see fol. <span data-fol="14r" class="fref">14</span>) are
 typical for the Convent of Mariënwater in Rosmalen (Netherlands), which
 is illustrated by the flowing pen strokes that curl into the margin. The
 Convent of Mariënwater was the first convent of the [Bridgettine
 Order](https://en.wikipedia.org/wiki/Bridgettines) in the Low Countries.
-In fol. 141v we can read that the manuscript once belonged to Marghrieta
+In fol. <span data-fol="141v" class="fref">141v</span> we can read that the manuscript once belonged to Marghrieta
 Peters Lamerts, prioress of Mariënwater, and that it remained in use in
 the convent until the end of the eighteenth century. There are
 annotations included from this period. By then, however, the convent was

--- a/_manuscripts/bpl-2856.md
+++ b/_manuscripts/bpl-2856.md
@@ -4,6 +4,7 @@ route: religion-devotion
 
 title: Psalms and bloodletting
 shelfmark: BPL 2856
+sort_as: BPL 2856
 origin: "Den Bosch, Netherlands"
 ms_date: "1450-1500"
 ms_title: Psalterium

--- a/_manuscripts/bpl-2905.md
+++ b/_manuscripts/bpl-2905.md
@@ -39,8 +39,7 @@ image of the Virgin.
 
 The decoration of this manuscript is unique, as there are no other known
 examples of the type of pen-flourished initials[^1] that are used within.
-In fol. 86r the illuminator has drawn the head of an animal and in fol.
-137r he has drawn a bird. Even though there are almost no annotations in
+In fol. 86r the illuminator has drawn the head of an animal and in fol. 137r he has drawn a bird. Even though there are almost no annotations in
 this manuscript, someone has added some staff-lines with musical notes
 in the margin (see fol. 52v, fol. 72v and fol. 186r).
 

--- a/_manuscripts/bpl-2905.md
+++ b/_manuscripts/bpl-2905.md
@@ -30,7 +30,7 @@ litanies. Both the books of hours and breviaries contained a [calendar
 of the feast days](https://en.wikipedia.org/wiki/Calendar_of_saints) of
 different saints. It is often possible to locate the precise location of
 production of a manuscript based on the saints that are mentioned on
-these calendars. For example, fol. 4r in this manuscript references
+these calendars. For example, fol. <span data-fol="4r" class="fref">4r</span> in this manuscript references
 March 17 as the feast day of Saint Gertrude *"in hac domo buscodis"*,
 which tells us that the manuscript was produced in or for the Convent of
 St. Gertrude in 's Hertogenbosch (the Netherlands). This convent,
@@ -39,9 +39,9 @@ image of the Virgin.
 
 The decoration of this manuscript is unique, as there are no other known
 examples of the type of pen-flourished initials[^1] that are used within.
-In fol. 86r the illuminator has drawn the head of an animal and in fol. 137r he has drawn a bird. Even though there are almost no annotations in
+In fol. <span data-fol="86r" class="fref">86r</span> the illuminator has drawn the head of an animal and in fol. <span data-fol="137r" class="fref">137r</span> he has drawn a bird. Even though there are almost no annotations in
 this manuscript, someone has added some staff-lines with musical notes
-in the margin (see fol. 52v, fol. 72v and fol. 186r).
+in the margin (see fol. <span data-fol="52v" class="fref">52v</span>, fol. <span data-fol="72v" class="fref">72v</span> and fol. <span data-fol="186r" class="fref">186r</span>).
 
 [^1]: [Decorating the Book: Penwork Flourishing]({{ "/glossary/#penwork-flourishing" | relative_url }})
 

--- a/_manuscripts/bpl-2905.md
+++ b/_manuscripts/bpl-2905.md
@@ -5,6 +5,7 @@ route: religion-devotion
 
 title: Breviarium
 shelfmark: BPL 2905
+sort_as: BPL 2905
 origin: "Den Bosch, Netherlands"
 ms_date: "c.1450-1500"
 ms_title: Breviarium 

--- a/_manuscripts/bpl-304.md
+++ b/_manuscripts/bpl-304.md
@@ -21,9 +21,9 @@ questions:
 
 This manuscript contains a vocabulary from the fifteenth century. Its
 structure is very clear: all words are written down in alphabetical
-order and divided into three parts. Part one describes nouns (fol. 1r -
-fol. 229v), part two covers verbs (fols. 229v - 273r) and part three
-covers adverbs, conjunctions, prepositions and interjections (fols. 273r - 279r).
+order and divided into three parts. Part one describes nouns (fol. <span data-fol="1r" class="fref">1r</span> -
+fol. <span data-fol="229v" class="fref">229v</span>), part two covers verbs (fols. <span data-fol="229v" class="fref">229v</span> - <span data-fol="273r" class="fref">273r</span>) and part three
+covers adverbs, conjunctions, prepositions and interjections (fols. <span data-fol="273r" class="fref">273r</span> - <span data-fol="279r" class="fref">279r</span>).
 This made it very easy for people to look up the meaning of a
 certain word. The empty spaces in the text were originally reserved for
 illumination but were never filled in.

--- a/_manuscripts/bpl-304.md
+++ b/_manuscripts/bpl-304.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: From Catholic to Protestant
 shelfmark: BPL 304
+sort_as: BPL 0304
 origin: "Northern Netherlands/Germany"
 ms_date: "1466"
 ms_creator: Henricus de Hervordia

--- a/_manuscripts/bpl-304.md
+++ b/_manuscripts/bpl-304.md
@@ -22,8 +22,8 @@ questions:
 This manuscript contains a vocabulary from the fifteenth century. Its
 structure is very clear: all words are written down in alphabetical
 order and divided into three parts. Part one describes nouns (fol. 1r -
-fol. 229v), part two covers verbs (fol. 229v - 273r) and part three
-covers adverbs, conjunctions, prepositions and interjections (fol. 273r - 279r).
+fol. 229v), part two covers verbs (fols. 229v - 273r) and part three
+covers adverbs, conjunctions, prepositions and interjections (fols. 273r - 279r).
 This made it very easy for people to look up the meaning of a
 certain word. The empty spaces in the text were originally reserved for
 illumination but were never filled in.

--- a/_manuscripts/bpl-3094.md
+++ b/_manuscripts/bpl-3094.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: A Surgeon's Manual
 shelfmark: BPL 3094
+sort_as: BPL 3094
 origin: "Southern Netherlands, Flanders"
 ms_date: "1475-1500"
 ms_title: Medical Compilation

--- a/_manuscripts/bpl-3094.md
+++ b/_manuscripts/bpl-3094.md
@@ -24,7 +24,7 @@ description of various diseases and how to treat them. The manual
 contains a small number of drawings that demonstrate how a surgeon
 should perform certain procedures and which instruments he should use.
 These images were more practical than detailed descriptions because they
-take up less space on the page. For example, fol. 82v shows a drawing
+take up less space on the page. For example, fol. <span data-fol="82v" class="fref">82v</span> shows a drawing
 depicting how different types of broken bones could be mended.
 
 The contents of the book were partly derived from the famous book

--- a/_manuscripts/bpl-3103.md
+++ b/_manuscripts/bpl-3103.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: Medicinal herbs and plants
 shelfmark: BPL 3103
+sort_as: BPL 3103
 origin: "South-Germany, Germany"
 ms_date: "c.1460"
 ms_title: Herbarium

--- a/_manuscripts/bpl-3284.md
+++ b/_manuscripts/bpl-3284.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: Medical recipes and remedies
 shelfmark: BPL 3284
+sort_as: BPL 3284
 origin: "Germany"
 ms_date: "1500-1550?"
 ms_title: Arzneibuch

--- a/_manuscripts/bpl-3284.md
+++ b/_manuscripts/bpl-3284.md
@@ -28,8 +28,7 @@ owners of this pharmacopoeia was Adam Krentzer, who wrote his name on
 the inside of the binding. This manuscript consists of nine parts, all
 written in German but easily distinguishable because of the variation in
 lay-out and script[^1]. Many readers of this manuscript have added remarks
-to the text, some of them even in Hebrew script (see for example fol.
-70v).
+to the text, some of them even in Hebrew script (see for example fol. 70v).
 
 When the parts of this manuscript were bound together, it received a
 parchment binding recycled from an unknown manuscript. The letters of

--- a/_manuscripts/bpl-3284.md
+++ b/_manuscripts/bpl-3284.md
@@ -28,7 +28,7 @@ owners of this pharmacopoeia was Adam Krentzer, who wrote his name on
 the inside of the binding. This manuscript consists of nine parts, all
 written in German but easily distinguishable because of the variation in
 lay-out and script[^1]. Many readers of this manuscript have added remarks
-to the text, some of them even in Hebrew script (see for example fol. 70v).
+to the text, some of them even in Hebrew script (see for example fol. <span data-fol="70v" class="fref">70v</span>).
 
 When the parts of this manuscript were bound together, it received a
 parchment binding recycled from an unknown manuscript. The letters of

--- a/_manuscripts/bpl-4.md
+++ b/_manuscripts/bpl-4.md
@@ -36,14 +36,14 @@ University Library has eight, each containing a part of *De civitate Dei.*
 
 This manuscript (BPL 4) contains chapter forty-three of the second book
 of *De civitate Dei*. As you can see, there are no annotations,
-indicating it was probably not used for study purposes. In fol. 2r we
+indicating it was probably not used for study purposes. In fol. <span data-fol="2r" class="fref">2r</span> we
 see two large decorated initials[^1], while other pages are decorated with
 smaller colored initials in red and blue. We can see from the owner
 marks on the flyleaves that this manuscript belonged to the Convent of
 St. Clara in Amsterdam around the year 1500, where it remained until
 1590 when the sisters of St. Clara were expelled from the city. After
 their expulsion, the manuscript came in the possession of Christophorus
-Dibuadius (*c*.1578-1621), a Danish scholar studying in Leiden. In fol. 139v you can read the exact date that the scribe finished copying the
+Dibuadius (*c*.1578-1621), a Danish scholar studying in Leiden. In fol. <span data-fol="139v" class="fref">139v</span> you can read the exact date that the scribe finished copying the
 text.
 
 [^1]: [Decorating the Book]({{ "/glossary/#decorating-the-book" | relative_url }})

--- a/_manuscripts/bpl-4.md
+++ b/_manuscripts/bpl-4.md
@@ -5,6 +5,7 @@ route: religion-devotion
 
 title: "The City of God"
 shelfmark: BPL 4
+sort_as: BPL 0004
 origin: "Italy"
 ms_date: "1453"
 ms_creator: Augustine

--- a/_manuscripts/bpl-4.md
+++ b/_manuscripts/bpl-4.md
@@ -43,8 +43,7 @@ marks on the flyleaves that this manuscript belonged to the Convent of
 St. Clara in Amsterdam around the year 1500, where it remained until
 1590 when the sisters of St. Clara were expelled from the city. After
 their expulsion, the manuscript came in the possession of Christophorus
-Dibuadius (*c*.1578-1621), a Danish scholar studying in Leiden. In fol.
-139v you can read the exact date that the scribe finished copying the
+Dibuadius (*c*.1578-1621), a Danish scholar studying in Leiden. In fol. 139v you can read the exact date that the scribe finished copying the
 text.
 
 [^1]: [Decorating the Book]({{ "/glossary/#decorating-the-book" | relative_url }})

--- a/_manuscripts/bpl-43.md
+++ b/_manuscripts/bpl-43.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: A real classic
 shelfmark: BPL 43
+sort_as: BPL 0043
 origin: "France?"
 ms_date: "1100-1200"
 ms_creator: Vergilius

--- a/_manuscripts/bpl-91.md
+++ b/_manuscripts/bpl-91.md
@@ -22,7 +22,7 @@ questions:
 The margins of this twelfth-century manuscript contain many glosses.
 They were added in the twelfth, thirteenth, and fourteenth-centuries,
 and show how this manuscript passed from one owner to the next, several
-of whom wrote their names on fol. 175v. The note at the bottom of the
+of whom wrote their names on fol. <span data-fol="175v" class="fref">175v</span>. The note at the bottom of the
 page reads that this manuscript belonged to the "commune bonorum
 puerorum", the "society of honorable boys", in the fourteenth century.
 The boys of this society probably used this manuscript to study

--- a/_manuscripts/bpl-91.md
+++ b/_manuscripts/bpl-91.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: Honorable Boys
 shelfmark: BPL 91
+sort_as: BPL 0091
 origin: "Italy"
 ms_date: "1100-1200"
 ms_creator: Priscianus

--- a/_manuscripts/gro-6.md
+++ b/_manuscripts/gro-6.md
@@ -23,8 +23,7 @@ questions:
 This manuscript belonged to professor of
 [rhetoric](https://en.wikipedia.org/wiki/Rhetoric) Michael Junta de
 Santa Croce of Florence. It is therefore no surprise that the five texts
-included concern the subject of rhetoric. Parts three and four (fol.
-56-115), written by Michael Junta himself, contain composed practical
+included concern the subject of rhetoric. Parts three and four (fols. 56 - 115), written by Michael Junta himself, contain composed practical
 exercises in Italian and a commentary on the [*Ad herennium*](https://en.wikipedia.org/wiki/Rhetorica_ad_Herennium) (here
 wrongly attributed to [Cicero](https://en.wikipedia.org/wiki/Cicero),
 see also BPL 195). Junta probably used these exercises during his

--- a/_manuscripts/gro-6.md
+++ b/_manuscripts/gro-6.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: Practical rhetorical exercises
 shelfmark: GRO 6
+sort_as: GRO 0006
 origin: "Florence, Italy"
 ms_date: "1300-1400"
 ms_creator: Cicero

--- a/_manuscripts/gro-6.md
+++ b/_manuscripts/gro-6.md
@@ -23,7 +23,7 @@ questions:
 This manuscript belonged to professor of
 [rhetoric](https://en.wikipedia.org/wiki/Rhetoric) Michael Junta de
 Santa Croce of Florence. It is therefore no surprise that the five texts
-included concern the subject of rhetoric. Parts three and four (fols. 56 - 115), written by Michael Junta himself, contain composed practical
+included concern the subject of rhetoric. Parts three and four (fols. <span data-fol="56r" class="fref">56</span> - <span data-fol="115v" class="fref">115</span>), written by Michael Junta himself, contain composed practical
 exercises in Italian and a commentary on the [*Ad herennium*](https://en.wikipedia.org/wiki/Rhetorica_ad_Herennium) (here
 wrongly attributed to [Cicero](https://en.wikipedia.org/wiki/Cicero),
 see also BPL 195). Junta probably used these exercises during his

--- a/_manuscripts/ltk-169.md
+++ b/_manuscripts/ltk-169.md
@@ -39,9 +39,9 @@ Maerlant: *De Rijmbijbel* (the Bible in Rhyme, see also LTK 168). This
 Bible was based on [Petrus
 Comestors'](https://en.wikipedia.org/wiki/Petrus_Comestor) *Historica
 scholastica.* The manuscript contains both medieval and early modern
-parts. The modern parts, one and three (fols. 1 - 3, fols. 7 - 20), are
+parts. The modern parts, one and three (fols. <span data-fol="1r" class="fref">1</span> - <span data-fol="3v" class="fref">3</span>, fols. <span data-fol="7r" class="fref">7</span> - <span data-fol="20v" class="fref">20</span>), are
 written on paper[^1], while parts two and four, written between 1300 and
-1325 (fol. 4, fols. 21 - 26), were copied on parchment.[^2]
+1325 (fol. <span data-fol="4r" class="fref">4</span>, fols. <span data-fol="21r" class="fref">21</span> - <span data-fol="26v" class="fref">26</span>), were copied on parchment.[^2]
 
 [^1]: [Choosing a Writing Support: Paper]({{ "/glossary/#paper" | relative_url }})
 

--- a/_manuscripts/ltk-169.md
+++ b/_manuscripts/ltk-169.md
@@ -39,9 +39,9 @@ Maerlant: *De Rijmbijbel* (the Bible in Rhyme, see also LTK 168). This
 Bible was based on [Petrus
 Comestors'](https://en.wikipedia.org/wiki/Petrus_Comestor) *Historica
 scholastica.* The manuscript contains both medieval and early modern
-parts. The modern parts, one and three (fols. 1-3, fols. 7-20), are
+parts. The modern parts, one and three (fols. 1 - 3, fols. 7 - 20), are
 written on paper[^1], while parts two and four, written between 1300 and
-1325 (fol. 4, fols. 21-26), were copied on parchment.[^2]
+1325 (fol. 4, fols. 21 - 26), were copied on parchment.[^2]
 
 [^1]: [Choosing a Writing Support: Paper]({{ "/glossary/#paper" | relative_url }})
 

--- a/_manuscripts/ltk-169.md
+++ b/_manuscripts/ltk-169.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: A self-help book for a king
 shelfmark: LTK 169
+sort_as: LTK 0169
 origin: "West-Flanders, Netherlands"
 ms_date: "1300-1325"
 ms_title: Heimelijkheid der heimelijkheden

--- a/_manuscripts/ltk-218.md
+++ b/_manuscripts/ltk-218.md
@@ -4,6 +4,7 @@ route: religion-devotion
 
 title: Three in One
 shelfmark: LTK 218
+sort_as: LTK 0218
 origin: "Holland, Netherlands"
 ms_date: "1450-1500"
 ms_title: Liedboek

--- a/_manuscripts/ltk-218.md
+++ b/_manuscripts/ltk-218.md
@@ -26,7 +26,7 @@ led to some loss of the text in the third part. Upon close inspection
 you can see that someone added the missing letters some time later (see
 fol. 66v as an example).
 
-The first part of this manuscript (fol. 1r-53v) contains a
+The first part of this manuscript (fols. 1r - 53v) contains a
 [psalter](https://en.wikipedia.org/wiki/Psalter) and various prayers.
 This part once belonged to a Dominican monastery in Zwolle (the
 Netherlands). The second part consists of two sermons for the feast day

--- a/_manuscripts/ltk-218.md
+++ b/_manuscripts/ltk-218.md
@@ -24,16 +24,16 @@ produced at different times and places and then later bound together.
 During the binding process the leaves were cut to the same size, which
 led to some loss of the text in the third part. Upon close inspection
 you can see that someone added the missing letters some time later (see
-fol. 66v as an example).
+fol. <span data-fol="66v" class="fref">66v</span> as an example).
 
-The first part of this manuscript (fols. 1r - 53v) contains a
+The first part of this manuscript (fols. <span data-fol="1r" class="fref">1r</span> - <span data-fol="53v" class="fref">53v</span>) contains a
 [psalter](https://en.wikipedia.org/wiki/Psalter) and various prayers.
 This part once belonged to a Dominican monastery in Zwolle (the
 Netherlands). The second part consists of two sermons for the feast day
 of [St. Barbara](https://en.wikipedia.org/wiki/Saint_Barbara). The third
 part, however, is perhaps the most interesting part of this manuscript.
 It contains a hymnal owned and written by Marigen Remen, who was from
-either Leiden or Amsterdam (see fol. 65v). Even though her script is
+either Leiden or Amsterdam (see fol. <span data-fol="65v" class="fref">65v</span>). Even though her script is
 rough and her grammar poor the text is easy to read.
 
 The red dots on each page are added as decoration to fill up the

--- a/_manuscripts/ltk-237.md
+++ b/_manuscripts/ltk-237.md
@@ -32,10 +32,9 @@ devotional education.
 
 Even though parts 2, 3, 5, and 6 are printed texts, their lay-out,
 script, and decorations look similar to that of a manuscript. The
-printers included decorated initials by either printing them (see fols.
-70r, 84r, and 159r) or leaving a blank space for the illuminator or
-reader to fill in (see for example fol. 167r). The person who drew the
-initial on fol. 167r probably also colored the letters of the other
+printers included decorated initials by either printing them (see fols. <span data-fol="70r" class="fref">70r</span>, <span data-fol="84r" class="fref">84r</span>, and <span data-fol="159r" class="fref">159r</span>) or leaving a blank space for the illuminator or
+reader to fill in (see for example fol. <span data-fol="167r" class="fref">167r</span>). The person who drew the
+initial on fol. <span data-fol="167r" class="fref">167r</span> probably also colored the letters of the other
 printed texts and contributed to the illustrations of part two and
 three. The first leaf of the fourth part, which consists of fols.
 93-158, is heavily stained and shows that this text has circulated

--- a/_manuscripts/ltk-237.md
+++ b/_manuscripts/ltk-237.md
@@ -4,6 +4,7 @@ route: religion-devotion
 
 title: Written and printed
 shelfmark: LTK 237
+sort_as: LTK 0237
 origin: "Netherlands"
 ms_date: "1400-1550"
 ms_title: Gebeden en Meditatiën

--- a/_manuscripts/ltk-247.md
+++ b/_manuscripts/ltk-247.md
@@ -4,6 +4,7 @@ route: religion-devotion
 
 title: Secret language
 shelfmark: LTK 247
+sort_as: LTK 0247
 origin: "Purmerend, Netherlands"
 ms_date: "1463"
 ms_creator: Johannes Scutken

--- a/_manuscripts/ltk-263.md
+++ b/_manuscripts/ltk-263.md
@@ -38,7 +38,7 @@ Voragine](https://en.wikipedia.org/wiki/Jacobus_da_Varagine) (see also
 LTK 278). This text is credited for making popular the legend of St.
 Ursula. De Voragine only briefly discusses St. Basilia in the *Legenda
 Aurea,* but a member of the convent added two leaves to the back of the
-manuscript with more information about her life (fols. 177r - 178v). The
+manuscript with more information about her life (fols. <span data-fol="177r" class="fref">177r</span> - <span data-fol="178v" class="fref">178v</span>). The
 manuscript contains rubrics and is decorated with colored initials.
 
 {% cite liecodices --locator 77-78 %}

--- a/_manuscripts/ltk-263.md
+++ b/_manuscripts/ltk-263.md
@@ -4,6 +4,7 @@ route: religion-devotion
 
 title: One of the 11.000 virgins
 shelfmark: LTK 263
+sort_as: LTK 0263
 origin: "Leiden?, Netherlands"
 ms_date: "1437"
 ms_creator: Jacobus de Voragine

--- a/_manuscripts/ltk-278.md
+++ b/_manuscripts/ltk-278.md
@@ -35,7 +35,7 @@ This copy contains the oldest Dutch *Legenda Aurea* translation. The
 manuscript does not contain the whole text but only the text that
 corresponds with the months July through November, considered the
 "summer part". The manuscript was written in 1420, probably by Willem
-van der Does from Leiden for his own personal use[^1] (see. fol. 1v.). The
+van der Does from Leiden for his own personal use[^1] (see. fol. 1v). The
 script is written in small cursive script, making it unsuitable to read
 in a monastery refectory. Also, there are too few decorations for it to
 have been considered for display in a church. The manuscript contains

--- a/_manuscripts/ltk-278.md
+++ b/_manuscripts/ltk-278.md
@@ -35,7 +35,7 @@ This copy contains the oldest Dutch *Legenda Aurea* translation. The
 manuscript does not contain the whole text but only the text that
 corresponds with the months July through November, considered the
 "summer part". The manuscript was written in 1420, probably by Willem
-van der Does from Leiden for his own personal use[^1] (see. fol. 1v). The
+van der Does from Leiden for his own personal use[^1] (see. fol. <span data-fol="1v" class="fref">1v</span>). The
 script is written in small cursive script, making it unsuitable to read
 in a monastery refectory. Also, there are too few decorations for it to
 have been considered for display in a church. The manuscript contains

--- a/_manuscripts/ltk-278.md
+++ b/_manuscripts/ltk-278.md
@@ -4,6 +4,7 @@ route: religion-devotion
 
 title: Saints and legends
 shelfmark: LTK 278
+sort_as: LTK 0278
 origin: "Leiden?, Netherlands"
 ms_date: "1420"
 ms_creator: Jacobus de Voragine

--- a/_manuscripts/ltk-284.md
+++ b/_manuscripts/ltk-284.md
@@ -4,6 +4,7 @@ route: religion-devotion
 
 title: Geert Groote
 shelfmark: LTK 284
+sort_as: LTK 0284
 origin: "Utrecht, Netherlands"
 ms_date: "1500-1550?"
 ms_title: Getijdenboek

--- a/_manuscripts/ltk-284.md
+++ b/_manuscripts/ltk-284.md
@@ -33,8 +33,8 @@ nearly all Dutch copies of the book of hours.
 
 An owner from the eighteenth century has added a table of contents[^1] to
 the first flyleaf. The manuscript begins with a calendar of the
-bishopric of Utrecht (p. 1), followed by prayers and hymns (p. 25), and
-lastly, the hours (pp. 123-474). The manuscript is decorated with
+bishopric of Utrecht (p. <span data-fol="1" class="fref">1</span>), followed by prayers and hymns (p. <span data-fol="25" class="fref">25</span>), and
+lastly, the hours (pp. <span data-fol="123" class="fref">123</span> - <span data-fol="474" class="fref">474</span>). The manuscript is decorated with
 pen-flourished initials in green, red and blue. The leaves are dark with
 staining, probably due to water damage.
 

--- a/_manuscripts/ltk-287.md
+++ b/_manuscripts/ltk-287.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: Religious manual or status symbol?
 shelfmark: LTK 287
+sort_as: LTK 0287
 origin: "Delft, Netherlands"
 ms_date: "c.1460"
 ms_title: Lekenbrevier

--- a/_manuscripts/ltk-303.md
+++ b/_manuscripts/ltk-303.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: How to suffer with Christ
 shelfmark: LTK 303
+sort_as: LTK 0303
 origin: "Tongeren, Southern Netherlands"
 ms_date: "1500-1550"
 ms_title: Passieboek

--- a/_manuscripts/ltk-303.md
+++ b/_manuscripts/ltk-303.md
@@ -34,8 +34,8 @@ that this Passion book was written for a citizen of the Flemish city
 [Tongeren](https://en.wikipedia.org/wiki/Tongeren).
 
 This manuscript is decorated with colored and pen-flourished initials.
-The historiated initial[^1] 'O' on fol. 156r depicts the five wounds that
-Jesus suffered during the crucifixion. Fol. 222v once contained a
+The historiated initial[^1] 'O' on fol. <span data-fol="156r" class="fref">156r</span> depicts the five wounds that
+Jesus suffered during the crucifixion. Fol. <span data-fol="222v" class="fref">222v</span> once contained a
 pasted-on miniature, and although it has since been removed you can
 still see the where the miniature was once pasted to the leaf.
 

--- a/_manuscripts/ltk-304.md
+++ b/_manuscripts/ltk-304.md
@@ -31,8 +31,7 @@ hospital of Siena, taking care those infected by the plague.
 This book of hours is written in both Latin and Dutch. Since most lay
 people (and many nuns) were unable to read Latin it was probably owned
 by a monastery with male members, most likely from the order of
-Augustine (see the prayer to "our dear father St. Augustine" at fol.
-147v.). The monks could have used this book of hours either during the
+Augustine (see the prayer to "our dear father St. Augustine" at fol. 147v). The monks could have used this book of hours either during the
 Divine Office or during personal meditation. By listing January 8^th^ as
 the feast day of St. Goedele in the manuscript's calendar we are given
 another hint as to where this book was produced. It is believed that

--- a/_manuscripts/ltk-304.md
+++ b/_manuscripts/ltk-304.md
@@ -31,7 +31,7 @@ hospital of Siena, taking care those infected by the plague.
 This book of hours is written in both Latin and Dutch. Since most lay
 people (and many nuns) were unable to read Latin it was probably owned
 by a monastery with male members, most likely from the order of
-Augustine (see the prayer to "our dear father St. Augustine" at fol. 147v). The monks could have used this book of hours either during the
+Augustine (see the prayer to "our dear father St. Augustine" at fol. <span data-fol="147v" class="fref">147v</span>). The monks could have used this book of hours either during the
 Divine Office or during personal meditation. By listing January 8^th^ as
 the feast day of St. Goedele in the manuscript's calendar we are given
 another hint as to where this book was produced. It is believed that

--- a/_manuscripts/ltk-304.md
+++ b/_manuscripts/ltk-304.md
@@ -4,6 +4,7 @@ route: religion-devotion
 
 title: Preventing Plague through Prayer
 shelfmark: LTK 304
+sort_as: LTK 0304
 origin: "Brabant, Netherlands"
 ms_date: "1550"
 ms_title: Getijdenboek

--- a/_manuscripts/ltk-316.md
+++ b/_manuscripts/ltk-316.md
@@ -4,6 +4,7 @@ route: religion-devotion
 
 title: Jesus in hell
 shelfmark: LTK 316
+sort_as: LTK 0316
 origin: "Utrecht?, Netherlands"
 ms_date: "1400-1450?"
 ms_title: Passieboek van Nicodemus

--- a/_manuscripts/ltk-318.md
+++ b/_manuscripts/ltk-318.md
@@ -4,6 +4,7 @@ route: religion-devotion
 
 title: Memento mori
 shelfmark: LTK 318
+sort_as: LTK 0318
 origin: "Gouda, Netherlands"
 ms_date: "1476"
 ms_title: Sermoenen

--- a/_manuscripts/ltk-318.md
+++ b/_manuscripts/ltk-318.md
@@ -18,7 +18,7 @@ questions:
 - b7
 ---
 
-Fol. 173v of this manuscripts contains the inscription "This book was
+Fol. <span data-fol="173v" class="fref">173v</span> of this manuscripts contains the inscription "This book was
 written for Claes van Dorssen and his wife Yde". When Claes died, in
 1477, his wife Yde donated the manuscript to the Convent of
 [Mariënsterre](https://nl.wikipedia.org/wiki/Regulierenklooster_(Gouda))
@@ -37,7 +37,7 @@ ownership.
 
 In the first part of this manuscript someone used a pencil to trace the
 [watermarks](https://en.wikipedia.org/wiki/Watermark)[^1] on the paper
-(see fols. 7v, 35v, and 66v). Watermarks were produced by attaching an
+(see fols. <span data-fol="7v" class="fref">7v</span>, <span data-fol="35v" class="fref">35v</span>, and <span data-fol="66v" class="fref">66v</span>). Watermarks were produced by attaching an
 emblem made of brass-wire to the screen of a paper mold. In order to
 make it possible to identify the maker or place of origin, each
 papermaker used a signature watermark design, much like a logo. This

--- a/_manuscripts/ltk-336.md
+++ b/_manuscripts/ltk-336.md
@@ -18,7 +18,7 @@ questions:
 - b7
 ---
 
-The scribe of this manuscript wrote at fol. 141v that she finished
+The scribe of this manuscript wrote at fol. <span data-fol="141v" class="fref">141v</span> that she finished
 writing it in 1533 and that it belonged to the "*witte nonnen*" of
 Leiden. The so-called white nuns were members of the
 [Dominican](https://en.wikipedia.org/wiki/Dominican_Order) Convent of
@@ -34,7 +34,7 @@ follows a reading of scripture) by several Christian authors, including
 Bede, Augustine and John Chrysostom. The scribe has copied these
 homilies from the first book of Collationes by Dirc van Herxen (see also
 BPL 2231). The first pages of the manuscript contain many reader's
-annotations. At fol. 188r, 188v, and 190v you can see drawings of small
+annotations. At fol. <span data-fol="188r" class="fref">188r</span>, <span data-fol="188v" class="fref">188v</span>, and <span data-fol="190v" class="fref">190v</span> you can see drawings of small
 hands pointing to specific sentences in the text. These hands, called
 *manicula*[^1], show the reader which passages deserve extra attention and
 appear often in medieval manuscripts. The shape of the hand and the

--- a/_manuscripts/ltk-336.md
+++ b/_manuscripts/ltk-336.md
@@ -4,6 +4,7 @@ route: religion-devotion
 
 title: The white nuns of Leiden
 shelfmark: LTK 336
+sort_as: LTK 0336
 origin: "Leiden, Netherlands"
 ms_date: "1533-1534"
 ms_title: Homilien

--- a/_manuscripts/per-q-85.md
+++ b/_manuscripts/per-q-85.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: A Modern Example
 shelfmark: PER Q 85
+sort_as: PER Q 0085
 origin: "Netherlands"
 ms_date: "1760"
 ms_creator: Adhelmus

--- a/_manuscripts/sca-1.md
+++ b/_manuscripts/sca-1.md
@@ -4,6 +4,7 @@ route: liberal-arts-education
 
 title: A medieval calculator
 shelfmark: SCA 1
+sort_as: SCA 0001
 origin: "France"
 ms_date: "1400"
 ms_creator: Adelard of Bath

--- a/_manuscripts/sca-1.md
+++ b/_manuscripts/sca-1.md
@@ -37,7 +37,7 @@ and *De musica.* These four texts were used to study the "quadrivium":
 arithmetic, geometry, music and astronomy. This copy of the *Regulae abaci* was decorated by an illuminator known as the Virgil Master, who
 worked at the court of Jean de Berry from the 1390s to the 1410s. He
 added many pen-flourished initials and a beautifully historiated
-initial[^1] on fol. 1r. The scribe has also added a form of decoration by
+initial[^1] on fol. <span data-fol="1r" class="fref">1r</span>. The scribe has also added a form of decoration by
 extending the ascending and descending the strokes of some of the
 letters of the first and last line of every page.
 

--- a/_manuscripts/vcf-11.md
+++ b/_manuscripts/vcf-11.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: A Note on Alchemy
 shelfmark: VCF 11
+sort_as: VCF 0011
 origin: "Germany"
 ms_date: "1590"
 ms_title: Tractatus de Alchimia

--- a/_manuscripts/vcf-12.md
+++ b/_manuscripts/vcf-12.md
@@ -38,9 +38,9 @@ significant Bohemian noble family. In 1609 he added an
 flyleaf of the manuscript to indicate his ownership. Other notable
 owners of this manuscript were lay alchemist Lorentz Zatzer (whose
 initials are slightly visible on the cover of the manuscript) and [Isaac
-Vossius](https://en.wikipedia.org/wiki/Isaac_Vossius) (fol. 1r). There
-is an additional name that was crossed out on fol. 195v. These owners --
-and perhaps others -- added several notes in the margins. From fol. 131v
+Vossius](https://en.wikipedia.org/wiki/Isaac_Vossius) (fol. <span data-fol="1r" class="fref">1r</span>). There
+is an additional name that was crossed out on fol. <span data-fol="195v" class="fref">195v</span>. These owners --
+and perhaps others -- added several notes in the margins. From fol. <span data-fol="131v" class="fref">131v</span>
 onwards you can see many maniculae[^1]; drawings of tiny hands used to
 point to relevant passages in the text.
 

--- a/_manuscripts/vcf-12.md
+++ b/_manuscripts/vcf-12.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: The marvelous doctor
 shelfmark: VCF 12
+sort_as: VCF 0012
 origin: "Germany"
 ms_date: "1575"
 ms_title: Omnia Germanice

--- a/_manuscripts/vcf-13.md
+++ b/_manuscripts/vcf-13.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: A royal owner
 shelfmark: VCF 13
+sort_as: VCF 0013
 origin: "Germany"
 ms_date: "1575-1600"
 ms_title: Tractatatulus de lapide philosophorum

--- a/_manuscripts/vcf-13.md
+++ b/_manuscripts/vcf-13.md
@@ -23,7 +23,7 @@ Manuscripts were often used by a variety of readers. The first reader of
 this manuscript, the person for whom the manuscript was produced, was
 [Sebald Schwertzer](https://de.wikipedia.org/wiki/Sebalt_Schwertzer)
 (1552-1598), a German merchant and alchemist who worked at the court of
-Dresden. We know this because he wrote his name on fol. 57r. In the
+Dresden. We know this because he wrote his name on fol. <span data-fol="57r" class="fref">57r</span>. In the
 beginning of the seventeenth century this manuscript came into the
 possession of [Christina, Queen of
 Sweden](https://en.wikipedia.org/wiki/Christina,_Queen_of_Sweden)
@@ -36,8 +36,8 @@ the letters VCF belonged to this collection.
 
 This manuscript, which was copied by two different scribes, contains
 treatises on alchemy and medical recipes, and includes several letters.
-The name of the scribe who wrote fols. 1r - 166v is Hans Meissel, who also
-copied VCF 6, VCF 14 and VCF 21. The text on fols. 176r - 178v is about
+The name of the scribe who wrote fols. <span data-fol="1r" class="fref">1r</span> - <span data-fol="166v" class="fref">166v</span> is Hans Meissel, who also
+copied VCF 6, VCF 14 and VCF 21. The text on fols. <span data-fol="176r" class="fref">176r</span> - <span data-fol="178v" class="fref">178v</span> is about
 necromancy: a practice that teaches communication with the deceased as a
 means to foretell the future or discover hidden knowledge. Many people
 regarded necromancy as black magic and not as a real science.

--- a/_manuscripts/vcf-13.md
+++ b/_manuscripts/vcf-13.md
@@ -36,8 +36,8 @@ the letters VCF belonged to this collection.
 
 This manuscript, which was copied by two different scribes, contains
 treatises on alchemy and medical recipes, and includes several letters.
-The name of the scribe who wrote fols. 1r-166v is Hans Meissel, who also
-copied VCF 6, VCF 14 and VCF 21. The text on fols. 176r-178v is about
+The name of the scribe who wrote fols. 1r - 166v is Hans Meissel, who also
+copied VCF 6, VCF 14 and VCF 21. The text on fols. 176r - 178v is about
 necromancy: a practice that teaches communication with the deceased as a
 means to foretell the future or discover hidden knowledge. Many people
 regarded necromancy as black magic and not as a real science.

--- a/_manuscripts/vcf-14.md
+++ b/_manuscripts/vcf-14.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: Magic and spirits
 shelfmark: VCF 14
+sort_as: VCF 0014
 origin: "Germany"
 ms_date: "1577-1600"
 ms_title: Explanatio artis cabalisticae

--- a/_manuscripts/vcf-14.md
+++ b/_manuscripts/vcf-14.md
@@ -33,7 +33,7 @@ The fourth text of this manuscript is the third volume of [Johannes
 Trithemius'](https://en.wikipedia.org/wiki/Johannes_Trithemius)
 *Steganographia.* This volume, believed to be about magic, was placed on
 the "List of Prohibited Books" in 1609. The texts describe how spirits
-can be used to communicate over long distances. Fol. 76r and fol. 76v
+can be used to communicate over long distances. Fol. <span data-fol="76r" class="fref">76r</span> and fol. <span data-fol="76v" class="fref">76v</span>
 contain a list of the thirty-one so-called Aerial Spirits, also known as
 [jinn](https://en.wikipedia.org/wiki/Jinn). The first column lists the
 names of these spirits, the second column shows their symbols and the

--- a/_manuscripts/vcf-15.md
+++ b/_manuscripts/vcf-15.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: The most precious gift of God
 shelfmark: VCF 15
+sort_as: VCF 0015
 origin: "Germany"
 ms_date: "1575-1600"
 ms_title: Pretiosissimum Donum Dei

--- a/_manuscripts/vcf-15.md
+++ b/_manuscripts/vcf-15.md
@@ -39,7 +39,7 @@ From fol. 242r onwards the scribe has added many drawings of the various
 laboratory glassware items used in chemical experiments. There are also
 drawings of complicated constructions that look like small buildings
 (see fol. 253v). This manuscript was copied by two scribes. The second
-scribe (who copied fols. 139-345) wrote down his initials on fol. 345v:
+scribe (who copied fols. 139 - 345) wrote down his initials on fol. 345v:
 SPD.
 
 {% cite boecodices --locator 49-51 %}

--- a/_manuscripts/vcf-15.md
+++ b/_manuscripts/vcf-15.md
@@ -35,11 +35,11 @@ Villanova](https://en.wikipedia.org/wiki/Arnaldus_de_Villa_Nova) (c.
 1240-1311). De Villanova was an alchemist, astrologer, and physician who
 translated many Arabic medical texts into Latin.
 
-From fol. 242r onwards the scribe has added many drawings of the various
+From fol. <span data-fol="242r" class="fref">242r</span> onwards the scribe has added many drawings of the various
 laboratory glassware items used in chemical experiments. There are also
 drawings of complicated constructions that look like small buildings
-(see fol. 253v). This manuscript was copied by two scribes. The second
-scribe (who copied fols. 139 - 345) wrote down his initials on fol. 345v:
+(see fol. <span data-fol="253v" class="fref">253v</span>). This manuscript was copied by two scribes. The second
+scribe (who copied fols. <span data-fol="139r" class="fref">139</span> - <span data-fol="345v" class="fref">345</span>) wrote down his initials on fol. <span data-fol="345v" class="fref">345v</span>:
 SPD.
 
 {% cite boecodices --locator 49-51 %}

--- a/_manuscripts/vcf-16.md
+++ b/_manuscripts/vcf-16.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: A medical pioneer
 shelfmark: VCF 16
+sort_as: VCF 0016
 origin: "Germany"
 ms_date: "1550-1600"
 ms_creator: Theophrastus Paracelsus

--- a/_manuscripts/vcf-16.md
+++ b/_manuscripts/vcf-16.md
@@ -34,12 +34,12 @@ This manuscript contains several texts by Paracelsus on both medical and
 alchemical topics. It also contains a treatise on the Philosopher's
 Stone by [Isaac
 Hollandius](https://de.wikipedia.org/wiki/Johann_Isaac_Hollandus) (see
-VCQ 37) and short passages on alchemical recipes and experiments. Fol. 9v, for example, describes a remedy to treat snake bites. Fol. 10r
+VCQ 37) and short passages on alchemical recipes and experiments. Fol. <span data-fol="9v" class="fref">9v</span>, for example, describes a remedy to treat snake bites. Fol. <span data-fol="10r" class="fref">10r</span>
 contains an improved recipe against epilepsy. Until the nineteenth
 century, this manuscript had a parchment cover[^1] made from an official
 document from 1473.
 
-The texts were written by five different scribes. Scribe A (fols. 1 - 56,
+The texts were written by five different scribes. Scribe A (fols. <span data-fol="1r" class="fref">1</span> - <span data-fol="56v" class="fref">56</span>,
 94-100) is particularly hard to read because of the thick pen-strokes
 and the ink that has leaked through to the other side of the leaves.
 

--- a/_manuscripts/vcf-16.md
+++ b/_manuscripts/vcf-16.md
@@ -34,13 +34,12 @@ This manuscript contains several texts by Paracelsus on both medical and
 alchemical topics. It also contains a treatise on the Philosopher's
 Stone by [Isaac
 Hollandius](https://de.wikipedia.org/wiki/Johann_Isaac_Hollandus) (see
-VCQ 37) and short passages on alchemical recipes and experiments. Fol.
-9v, for example, describes a remedy to treat snake bites. Fol. 10r
+VCQ 37) and short passages on alchemical recipes and experiments. Fol. 9v, for example, describes a remedy to treat snake bites. Fol. 10r
 contains an improved recipe against epilepsy. Until the nineteenth
 century, this manuscript had a parchment cover[^1] made from an official
 document from 1473.
 
-The texts were written by five different scribes. Scribe A (fols. 1-56,
+The texts were written by five different scribes. Scribe A (fols. 1 - 56,
 94-100) is particularly hard to read because of the thick pen-strokes
 and the ink that has leaked through to the other side of the leaves.
 

--- a/_manuscripts/vcf-17.md
+++ b/_manuscripts/vcf-17.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: Secret symbols
 shelfmark: VCF 17
+sort_as: VCF 0017
 origin: "Germany"
 ms_date: "1575-1600"
 ms_title: Various alchemical treatises

--- a/_manuscripts/vcf-17.md
+++ b/_manuscripts/vcf-17.md
@@ -32,9 +32,11 @@ use of symbols.
 This sixteenth-century manuscript starts with a list of symbols and
 their explanations. Some of these symbols are used throughout the book.
 The manuscript contains various alchemical texts, such as the tenth
-volume of [Paracelsus'](https://en.wikipedia.org/wiki/Paracelsus) *De gradationibus* (p.13-22) and several recipes.
+volume of [Paracelsus'](https://en.wikipedia.org/wiki/Paracelsus) *De gradationibus* (pp.
+<span data-fol="13" class="fref">13</span> - <span data-fol="22" class="fref">22</span>) and several recipes.
 
-The text on altimetry between pp. 209-217 was added later on. The
+The text on altimetry between pp. <span data-fol="209" class="fref">209</span> -
+<span data-fol="217" class="fref">217</span> was added later on. The
 elaborate drawings in this text illustrate how to measure various
 heights.
 

--- a/_manuscripts/vcf-18.md
+++ b/_manuscripts/vcf-18.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: A secret recipe
 shelfmark: VCF 18
+sort_as: VCF 0018
 origin: "Germany"
 ms_date: "1575-1586"
 ms_creator: Albertus Magnus

--- a/_manuscripts/vcf-18.md
+++ b/_manuscripts/vcf-18.md
@@ -23,9 +23,9 @@ questions:
 When and where a manuscript was written is not always known. The type of
 script is an important aid to help determine the production date. In
 some cases, scribes wrote down when they completed the manuscript or a
-portion of it. Here we see such notations at fols. 1r, 47r, 53v, 155v
-and 229v, which shows that the manuscript was written between 1575 and 1586.
-An outlier is encountered on fol. 225, where the scribe has
+portion of it. Here we see such notations at fols. <span data-fol="1r" class="fref">1r</span>, <span data-fol="47r" class="fref">47r</span>, <span data-fol="53v" class="fref">53v</span>, <span data-fol="155v" class="fref">155v</span> and <span data-fol="229v" class="fref">229v</span>,
+which shows that the manuscript was written between 1575 and 1586.
+An outlier is encountered on fol. <span data-fol="225r" class="fref">225</span>, where the scribe has
 written down "1546 23 Martii MAB" (MAB are the initials of the scribe
 Magister Abraham Behem). This particular date could easily have been
 copied by accident from the exemplar. This inconsistency in recorded
@@ -39,7 +39,7 @@ Magnus, a German bishop and scholar, wrote about many topics, including
 logic, theology, geography, astrology, and alchemy. The manuscript
 contains annotations and drawings of [laboratory
 glassware](https://en.wikipedia.org/wiki/Laboratory_glassware) and other
-chemical equipment that were created by readers. Fols. 152r - 154r
+chemical equipment that were created by readers. Fols. <span data-fol="152r" class="fref">152r</span> - <span data-fol="154r" class="fref">154r</span>
 contain lists of alchemical symbols (see also VCF 17). One of the
 readers also uses these symbols to annotate certain passages.
 

--- a/_manuscripts/vcf-18.md
+++ b/_manuscripts/vcf-18.md
@@ -39,7 +39,7 @@ Magnus, a German bishop and scholar, wrote about many topics, including
 logic, theology, geography, astrology, and alchemy. The manuscript
 contains annotations and drawings of [laboratory
 glassware](https://en.wikipedia.org/wiki/Laboratory_glassware) and other
-chemical equipment that were created by readers. Fols. 152r-154r
+chemical equipment that were created by readers. Fols. 152r - 154r
 contain lists of alchemical symbols (see also VCF 17). One of the
 readers also uses these symbols to annotate certain passages.
 

--- a/_manuscripts/vcf-20.md
+++ b/_manuscripts/vcf-20.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: Beneath the Binding
 shelfmark: VCF 20
+sort_as: VCF 0020
 origin: "Germany"
 ms_date: "1574"
 ms_title: Various works by Raymundus Lullus

--- a/_manuscripts/vcf-20.md
+++ b/_manuscripts/vcf-20.md
@@ -34,7 +34,7 @@ Raymundus Lullus. [Lullus](https://en.wikipedia.org/wiki/Ramon_Llull)
 various subjects. The scribe and first owner of this manuscript was
 physician Lorentz Zatzer. Zatzer included two of his own recipes in the
 manuscript. Whenever he finished copying a certain passage he wrote down
-his name and the date (see for example fol. 110r *Finis Lor. Zatz., vollendet den 1 Apprili Anno 1574*). Other owners of this manuscript
+his name and the date (see for example fol. <span data-fol="110r" class="fref">110r</span> *Finis Lor. Zatz., vollendet den 1 Apprili Anno 1574*). Other owners of this manuscript
 were Hans Thyle (see binding *Han Thyle 160*), [Cardinal Franz
 Dietrichstein](https://en.wikipedia.org/wiki/Franz_von_Dietrichstein),
 [Christina, Queen of

--- a/_manuscripts/vcf-20.md
+++ b/_manuscripts/vcf-20.md
@@ -34,7 +34,7 @@ Raymundus Lullus. [Lullus](https://en.wikipedia.org/wiki/Ramon_Llull)
 various subjects. The scribe and first owner of this manuscript was
 physician Lorentz Zatzer. Zatzer included two of his own recipes in the
 manuscript. Whenever he finished copying a certain passage he wrote down
-his name and the date (see for example fol. 110 *Finis Lor. Zatz., vollendet den 1 Apprili Anno 1574*). Other owners of this manuscript
+his name and the date (see for example fol. 110r *Finis Lor. Zatz., vollendet den 1 Apprili Anno 1574*). Other owners of this manuscript
 were Hans Thyle (see binding *Han Thyle 160*), [Cardinal Franz
 Dietrichstein](https://en.wikipedia.org/wiki/Franz_von_Dietrichstein),
 [Christina, Queen of

--- a/_manuscripts/vcf-21.md
+++ b/_manuscripts/vcf-21.md
@@ -30,9 +30,9 @@ with the metal iron and the element fire. The symbols of the planets
 were often used to denote chemical processes (see also VCF 17).
 
 This manuscript also contains a treatise on the [Philosopher's
-Stone](https://en.wikipedia.org/wiki/Philosopher%27s_stone) (fols. 1 - 17),
+Stone](https://en.wikipedia.org/wiki/Philosopher%27s_stone) (fols. <span data-fol="1r" class="fref">1</span> - <span data-fol="17v" class="fref">17</span>),
 texts by [Paracelsus](https://en.wikipedia.org/wiki/Paracelsus) (fols.
-96-131) and many alchemical and medicinal recipes (fols. 133 - 354). The
+96-131) and many alchemical and medicinal recipes (fols. <span data-fol="133r" class="fref">133</span> - <span data-fol="354v" class="fref">354</span>). The
 scribe of this manuscript was Hans Meissel, who also copied VCF 6, VCF
 13 and VCF 14. The readers' annotations are very minimal, and the
 manuscript does not look heavily used. The original binding has,

--- a/_manuscripts/vcf-21.md
+++ b/_manuscripts/vcf-21.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: Planets, metals and elements
 shelfmark: VCF 21
+sort_as: VCF 0021
 origin: "Germany"
 ms_date: "1572-1600"
 ms_title: Lapide Philosophorum

--- a/_manuscripts/vcf-21.md
+++ b/_manuscripts/vcf-21.md
@@ -30,9 +30,9 @@ with the metal iron and the element fire. The symbols of the planets
 were often used to denote chemical processes (see also VCF 17).
 
 This manuscript also contains a treatise on the [Philosopher's
-Stone](https://en.wikipedia.org/wiki/Philosopher%27s_stone) (fol. 1-17),
+Stone](https://en.wikipedia.org/wiki/Philosopher%27s_stone) (fols. 1 - 17),
 texts by [Paracelsus](https://en.wikipedia.org/wiki/Paracelsus) (fols.
-96-131) and many alchemical and medicinal recipes (fol. 133-354). The
+96-131) and many alchemical and medicinal recipes (fols. 133 - 354). The
 scribe of this manuscript was Hans Meissel, who also copied VCF 6, VCF
 13 and VCF 14. The readers' annotations are very minimal, and the
 manuscript does not look heavily used. The original binding has,

--- a/_manuscripts/vcf-22.md
+++ b/_manuscripts/vcf-22.md
@@ -20,9 +20,9 @@ questions:
 ---
 
 This manuscript was completed by the scribe Peter Jünger on December
-8th, 1586. We know this from the colophon on fol. 152v where he wrote
+8th, 1586. We know this from the colophon on fol. <span data-fol="152v" class="fref">152v</span> where he wrote
 "*Laus deo Gloria* (Praise and Glory to God) *Anno Christi 1568 8 Decembris*." Jünger used two kinds of script to copy the texts in the
-manuscript: Gothic cursive and Humanistic cursive. On fol. 30v you can
+manuscript: Gothic cursive and Humanistic cursive. On fol. <span data-fol="30v" class="fref">30v</span> you can
 see the transition from Gothic to Humanistic. One of the texts in this
 manuscript is *Alchemia et remediorum liber* (The Book of Alchemy and
 Medicine). The manuscript also contains a text on wine, beer, and

--- a/_manuscripts/vcf-22.md
+++ b/_manuscripts/vcf-22.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: Changing up the script
 shelfmark: VCF 22
+sort_as: VCF 0022
 origin: "Germany"
 ms_date: "1586"
 ms_title: Alchimia et remediorum

--- a/_manuscripts/vcf-23.md
+++ b/_manuscripts/vcf-23.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: The secret of secrets
 shelfmark: VCF 23
+sort_as: VCF 0023
 origin: "Germany"
 ms_date: "1568-1600"
 ms_creator: Aristotle

--- a/_manuscripts/vcf-23.md
+++ b/_manuscripts/vcf-23.md
@@ -33,9 +33,9 @@ Bacon](https://en.wikipedia.org/wiki/Roger_Bacon) often cited from this
 text and has added his own extensive glosses. In 1266 Jacob van Maerlant
 translated the text into Middle Dutch (see *De heimelijkheid der heimelijkheden* LTK 169).
 
-This manuscript contains part of the *Secretum secretorum* (fols. 20 - 41)
+This manuscript contains part of the *Secretum secretorum* (fols. <span data-fol="20r" class="fref">20</span> - <span data-fol="41v" class="fref">41</span>)
 and various other alchemical treatises. It is copied by six different
-scribes and written in German, Latin, and Greek. Fols. 144v - 145v
+scribes and written in German, Latin, and Greek. Fols. <span data-fol="144v" class="fref">144v</span> - <span data-fol="145v" class="fref">145v</span>
 contains horoscopes from January 9th, 1506 and January 12th, 1507.
 Just as many of the other manuscripts in this theme, this one was owned
 by Sebald Schwertzer, [Queen Christina of

--- a/_manuscripts/vcf-23.md
+++ b/_manuscripts/vcf-23.md
@@ -33,9 +33,9 @@ Bacon](https://en.wikipedia.org/wiki/Roger_Bacon) often cited from this
 text and has added his own extensive glosses. In 1266 Jacob van Maerlant
 translated the text into Middle Dutch (see *De heimelijkheid der heimelijkheden* LTK 169).
 
-This manuscript contains part of the *Secretum secretorum* (fol. 20-41)
+This manuscript contains part of the *Secretum secretorum* (fols. 20 - 41)
 and various other alchemical treatises. It is copied by six different
-scribes and written in German, Latin, and Greek. Fols. 144v- 145v
+scribes and written in German, Latin, and Greek. Fols. 144v - 145v
 contains horoscopes from January 9th, 1506 and January 12th, 1507.
 Just as many of the other manuscripts in this theme, this one was owned
 by Sebald Schwertzer, [Queen Christina of

--- a/_manuscripts/vcf-6.md
+++ b/_manuscripts/vcf-6.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: The philosopher's stone
 shelfmark: VCF 6
+sort_as: VCF 0006
 origin: "Dresden, Germany"
 ms_date: "1575-1600?"
 ms_title: Exorcisms

--- a/_manuscripts/vcf-6.md
+++ b/_manuscripts/vcf-6.md
@@ -26,20 +26,20 @@ believed that this substance was able to turn base metals into gold or
 silver, heal people from all sorts of illnesses, and even offer
 immortality for the people who consumed part of it. Philosopher and
 scientist [Albertus
-Magnus](https://en.wikipedia.org/wiki/Philosopher's_stone) (c.
+Magnus](https://en.wikipedia.org/wiki/Albertus_Magnus) (c.
 1193-1280) had, according to legend, discovered the Philosopher's Stone
 and passed it on to Thomas Aquinas. Most manuscripts that are included
 in this theme, including this one, contain one or more treatises on this
 famous substance.
 
-Fols. 12r-34v contains the text "*Vom Stein der Weisen*" (The Stone of
+Fols. 12r - 34v contains the text "*Vom Stein der Weisen*" (The Stone of
 the Wise). The manuscript also contains other alchemical texts from
 authors such as [Roger Bacon](https://en.wikipedia.org/wiki/Roger_Bacon)
 and Géber. The text in fol. 1 deals with
 [exorcism](https://en.wikipedia.org/wiki/Exorcism); the practice of
 casting out demons from a person who is believed to be possessed. The
 scribe of this manuscript was Hans Meissel, who also copied VCF 13, 14
-and 21.The first reader of this book was probably alchemist Sebald
+and 21. The first reader of this book was probably alchemist Sebald
 Schwertzer (1552-1598). In the seventeenth century it came into the
 possession of [Christina, Queen of
 Sweden](https://en.wikipedia.org/wiki/Christina,_Queen_of_Sweden)

--- a/_manuscripts/vcf-6.md
+++ b/_manuscripts/vcf-6.md
@@ -32,10 +32,10 @@ and passed it on to Thomas Aquinas. Most manuscripts that are included
 in this theme, including this one, contain one or more treatises on this
 famous substance.
 
-Fols. 12r - 34v contains the text "*Vom Stein der Weisen*" (The Stone of
+Fols. <span data-fol="12r" class="fref">12r</span> - <span data-fol="34v" class="fref">34v</span> contains the text "*Vom Stein der Weisen*" (The Stone of
 the Wise). The manuscript also contains other alchemical texts from
 authors such as [Roger Bacon](https://en.wikipedia.org/wiki/Roger_Bacon)
-and Géber. The text in fol. 1 deals with
+and Géber. The text in fol. <span data-fol="1r" class="fref">1</span> deals with
 [exorcism](https://en.wikipedia.org/wiki/Exorcism); the practice of
 casting out demons from a person who is believed to be possessed. The
 scribe of this manuscript was Hans Meissel, who also copied VCF 13, 14

--- a/_manuscripts/vcf-8.md
+++ b/_manuscripts/vcf-8.md
@@ -21,8 +21,7 @@ questions:
 "***Praesentem monstrat quaelibet herba Deum***" (Any blade of grass
 points to the presence of God). This quote from poet [Johannes
 Stigelius](https://de.wikipedia.org/wiki/Johann_Stigel) (1515-1562)
-begins this alchemical manuscript from 1585 (see "*anno MDLXXXV"* fol.
-1r). The quote possibly served as a reminder to the reader that the
+begins this alchemical manuscript from 1585 (see "*anno MDLXXXV"* fol. 1r). The quote possibly served as a reminder to the reader that the
 various (al)chemical recipes in this manuscript should be used to honor
 God and not for personal profit (see also VCF 11). Not every text in
 this manuscript is about alchemy, though. The manuscript starts with a
@@ -33,9 +32,8 @@ Syrian satirist and rhetorician. Another text Lucian is known for is his
 translated into Latin in 1518.
 
 The annotations in this manuscript are minimal. Someone, either the
-scribe or one of the readers, tipped in a small piece of paper (now fol.
-330) in order to add a diagram to a text on the *practica abbatis* (The
-monk's practica) by pseudo-Aquinas.[^1] Fol. 253r - 255v contains a text on
+scribe or one of the readers, tipped in a small piece of paper (now fol. 330) in order to add a diagram to a text on the *practica abbatis* (The
+monk's practica) by pseudo-Aquinas.[^1] Fols. 253r - 255v contains a text on
 a formula that was used by king Philip IV of France.
 
 [^1]: [Using the Book: Notes]({{ "/glossary/#notes" | relative_url }})

--- a/_manuscripts/vcf-8.md
+++ b/_manuscripts/vcf-8.md
@@ -21,7 +21,7 @@ questions:
 "***Praesentem monstrat quaelibet herba Deum***" (Any blade of grass
 points to the presence of God). This quote from poet [Johannes
 Stigelius](https://de.wikipedia.org/wiki/Johann_Stigel) (1515-1562)
-begins this alchemical manuscript from 1585 (see "*anno MDLXXXV"* fol. 1r). The quote possibly served as a reminder to the reader that the
+begins this alchemical manuscript from 1585 (see "*anno MDLXXXV"* fol. <span data-fol="1r" class="fref">1r</span>). The quote possibly served as a reminder to the reader that the
 various (al)chemical recipes in this manuscript should be used to honor
 God and not for personal profit (see also VCF 11). Not every text in
 this manuscript is about alchemy, though. The manuscript starts with a
@@ -32,8 +32,8 @@ Syrian satirist and rhetorician. Another text Lucian is known for is his
 translated into Latin in 1518.
 
 The annotations in this manuscript are minimal. Someone, either the
-scribe or one of the readers, tipped in a small piece of paper (now fol. 330) in order to add a diagram to a text on the *practica abbatis* (The
-monk's practica) by pseudo-Aquinas.[^1] Fols. 253r - 255v contains a text on
+scribe or one of the readers, tipped in a small piece of paper (now fol. <span data-fol="330r" class="fref">330</span>) in order to add a diagram to a text on the *practica abbatis* (The
+monk's practica) by pseudo-Aquinas.[^1] Fols. <span data-fol="253r" class="fref">253r</span> - <span data-fol="255v" class="fref">255v</span> contains a text on
 a formula that was used by king Philip IV of France.
 
 [^1]: [Using the Book: Notes]({{ "/glossary/#notes" | relative_url }})

--- a/_manuscripts/vcf-8.md
+++ b/_manuscripts/vcf-8.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: A friendly reminder
 shelfmark: VCF 8
+sort_as: VCF 0008
 origin: "Germany"
 ms_date: "1585"
 ms_title: Annotationes Magistri Pertissimi

--- a/_manuscripts/vcq-13.md
+++ b/_manuscripts/vcq-13.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: Medicine at the court
 shelfmark: VCQ 13
+sort_as: VCQ 0013
 origin: "Germany"
 ms_date: "1506-1526?"
 ms_title: Descriptiones Processum Diversorum Chymicorum

--- a/_manuscripts/vcq-13.md
+++ b/_manuscripts/vcq-13.md
@@ -24,7 +24,7 @@ I](https://en.wikipedia.org/wiki/Maximilian_I,_Holy_Roman_Emperor)
 an advocate for the development of arts and sciences. He was known to
 surround himself with famous scholars. This manuscript contains two
 treatises from a servant of a physician who worked at the court of
-Maximilian (fol. 12v). It is possible that the emperor was composing his
+Maximilian (fol. <span data-fol="12v" class="fref">12v</span>). It is possible that the emperor was composing his
 own [pharmacopoeia](https://en.wikipedia.org/wiki/Pharmacopoeia) - an
 official guide for the use and identification of medicine (see also BPL
 3284).
@@ -37,7 +37,7 @@ the front), most likely a priest from Regendorf, Germany. Even though
 the leaves provide plenty of space for commentary, the readers' notes[^1]
 in this manuscript are minimal. Some of the pages are decorated with
 drawings of small bottles and other laboratory glassware (see for
-example fol. 9v).
+example fol. <span data-fol="9v" class="fref">9v</span>).
 
 [^1]: [Using the Book: Gloss]({{ "/glossary/#gloss" | relative_url }})
 

--- a/_manuscripts/vcq-37.md
+++ b/_manuscripts/vcq-37.md
@@ -39,9 +39,9 @@ sinusitis.
 
 The top of each page of this manuscript contains running titles[^1] in red
 ink, which made it much easier for the reader to see which treatise he
-or she was reading. From fol. 22v onwards the manuscript contains
+or she was reading. From fol. <span data-fol="22v" class="fref">22v</span> onwards the manuscript contains
 several drawings of various *laboratory glassware items*. There is an
-empty space on fol. 68v, which was probably meant for a more elaborate
+empty space on fol. <span data-fol="68v" class="fref">68v</span>, which was probably meant for a more elaborate
 drawing that was never completed.
 
 [^1]: [Reading Aids: Running Title]({{ "/glossary/#running-title" | relative_url }})

--- a/_manuscripts/vcq-37.md
+++ b/_manuscripts/vcq-37.md
@@ -4,6 +4,7 @@ route: diy-manuals
 
 title: Father and son
 shelfmark: VCQ 37
+sort_as: VCQ 0037
 origin: "Netherlands?"
 ms_date: "1500-1550?"
 ms_creator: Isaac Hollandus

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -56,15 +56,14 @@
 }
 
 #viewer {
-    /* flex: 1; */
-    position: relative;
+    position: sticky;
+    top: 10px;
     border: solid black;
     height: 500px;
 }
 nav.ms-title {
     display: flex !important;
     justify-content: space-between;
-    // border: dashed red;
 }
 nav.ms-title > h1 {
     display: inline-block;
@@ -73,7 +72,6 @@ nav.ms-title > h1 {
 #prev {
     /* align-content: start; */
     font-size: 3em;
-    /* flex: 1; */
     width: 100px;
     display: inline-block;
 }
@@ -81,13 +79,19 @@ nav.ms-title > h1 {
 #next {
     text-align: end;
     font-size: 3em;
-    /* flex: 1; */
     width: 100px;
     display: inline-block;
 }
 
 #description {
     margin-top: 10px;
+}
+
+span.fref {
+    text-decoration-style: dotted;
+    text-decoration-line: underline;
+    color: darkgreen;
+    cursor: pointer;
 }
 
 span.shelfmark {

--- a/index.md
+++ b/index.md
@@ -5,5 +5,20 @@ sidebar:
   nav: dmc
 ---
 
-Introduction to this resource.
+Welcome to Digital Manuscripts in the Classroom!
+This educational resource is a collection of selected digitised manuscripts
+from [Leiden University Libraries][ubl], organised in thematic routes.
+You are welcome to use (parts of) this collection in your classes. Please see
+the [colophon](colophon/) for details on how to use and improve these
+materials.
+*Digital Manuscripts in the Classroom is currently released in beta.*
 
+Each manuscript can be viewed in high resolution and read in the browser.
+Summaries with links to the included [glossary][g] and to Wikipedia, as well as
+links to specific parts of the manuscript, help students understand all
+aspects of the production and use of manuscripts.
+The study of these manuscripts is guided by a set of questions that can
+be answered by looking at the digitised objects.
+
+[ubl]: https://www.library.universiteitleiden.nl/
+[g]: glossary/


### PR DESCRIPTION
Clicking a reference to a folio or page in the description triggers the Mirador viewer to load the canvas that has that folio or page.

I found it easiest to update the markdown content with the `<span>` elements, although doing everything in JavaScript would have been nice too. References varied quite a bit and sometimes folio references did not have recto or verso.
Add to this mix the relience on the libraries' naming conventions for digitised items and "everything is fine".

Unrelated but good are addition of a homepage introduction text, making the viewer sticky so that you can see the 'page flipping' and adding a sort key to each manuscript.