### PR TITLE
Use the better-cached setup-ruby action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,17 +7,13 @@ jobs:
   jekyll:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Use GitHub Actions' cache to shorten build times and decrease load on servers
-    - uses: actions/cache@v2
+    - uses: ruby/setup-ruby@v1
       with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
+        ruby-version: '2.7'
+        bundler-cache: true
 
     # Standard usage
-    - uses:  helaili/jekyll-action@v2
-      with:
-        build_only: true
+    - run: bundle exec jekyll build


### PR DESCRIPTION
Caching in the PR workflow didn't work; using [setup-ruby](https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby) is preferred when you want to cache Gems.