### PR TITLE
Require uri 1.0.3 in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
-    uri (1.0.2)
+    uri (1.0.3)
     webrick (1.9.0)
 
 PLATFORMS


### PR DESCRIPTION
In response to a Dependabot security notice.