### PR TITLE
Support and test with Ruby 3.4

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   jekyll:
+    strategy:
+      matrix:
+        ruby_version: ['3.3', '3.4']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -12,7 +15,7 @@ jobs:
     # Use GitHub Actions' cache to shorten build times and decrease load on servers
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
+        ruby-version: ${{ matrix.ruby_version }}
         bundler-cache: true
 
     # Standard usage

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,12 @@ group :jekyll_plugins do
   gem "jekyll-target-blank"
 end
 
+# Required since Ruby >= 3.4.0 does not include some modules in the standard library
+gem "csv"
+gem "base64"
+gem "bigdecimal"
+gem "observer"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,9 +3,11 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.2.0)
     bibtex-ruby (6.1.0)
       latex-decode (~> 0.0)
       racc (~> 1.7)
+    bigdecimal (3.1.9)
     citeproc (1.0.10)
       namae (~> 1.0)
     citeproc-ruby (1.1.14)
@@ -18,6 +20,7 @@ GEM
       rexml
     csl-styles (1.0.1.11)
       csl (~> 1.0)
+    csv (3.3.2)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -28,16 +31,16 @@ GEM
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
-    ffi (1.17.0-aarch64-linux-gnu)
-    ffi (1.17.0-aarch64-linux-musl)
-    ffi (1.17.0-arm-linux-gnu)
-    ffi (1.17.0-arm-linux-musl)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86-linux-gnu)
-    ffi (1.17.0-x86-linux-musl)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
-    ffi (1.17.0-x86_64-linux-musl)
+    ffi (1.17.1-aarch64-linux-gnu)
+    ffi (1.17.1-aarch64-linux-musl)
+    ffi (1.17.1-arm-linux-gnu)
+    ffi (1.17.1-arm-linux-musl)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86-linux-gnu)
+    ffi (1.17.1-x86-linux-musl)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.1-x86_64-linux-musl)
     forwardable-extended (2.6.0)
     http_parser.rb (0.8.0)
     i18n (1.14.6)
@@ -122,6 +125,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.3-x86_64-linux-musl)
       racc (~> 1.4)
+    observer (0.1.2)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -163,12 +167,16 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  base64
+  bigdecimal
+  csv
   jekyll (~> 4)
   jekyll-feed
   jekyll-sass-converter (~> 2.2)
   jekyll-scholar
   jekyll-target-blank
   minimal-mistakes-jekyll
+  observer
   tzinfo-data
 
 BUNDLED WITH


### PR DESCRIPTION
My work laptop has Ruby 3.4.0, which removed certain modules from the standard library. After adding the missing modules as gems to the `Gemfile` to make it work on my machine, I figured it would be good to add Ruby 3.4 to the CI as well.