### PR TITLE
Clean up manuscript template

### DIFF
--- a/_layouts/default-ms.html
+++ b/_layouts/default-ms.html
@@ -23,20 +23,20 @@
       {{ content }}
     </div>
 
-    {% if site.search == true %}
+    {%- if site.search == true -%}
       <div class="search-content">
         {% include_cached search/search_form.html %}
       </div>
-    {% endif %}
+    {%- endif %}
 
     <div class="page__footer">
       <footer>
-        {% include footer/custom.html %}
+        {%- include footer/custom.html %}
         {% include_cached footer.html %}
       </footer>
     </div>
 
-    {% include scripts.html %}
+    {%- include scripts.html %}
 
   </body>
 </html>

--- a/_layouts/manuscript.html
+++ b/_layouts/manuscript.html
@@ -19,7 +19,7 @@ classes: wide
 </section>
 {% if page.questions %}
 <section id="questions">
-    <header><h1>Questions</h1></header>
+    <header><h2>Questions</h2></header>
     <ol>
         {%- for q in page.questions %}
         <li>{{ site.data.questions[q] }}</li>
@@ -28,7 +28,7 @@ classes: wide
 </section>
 {% endif %}
 <section id="related">
-    <header><h1>Related manuscripts</h1></header>
+    <header><h2>Related manuscripts</h2></header>
     <ol>
         {%- for ms in site.data.most_sim[page.shelfmark] %}
         {%- assign found_ms = site.manuscripts | find: "shelfmark", ms %}
@@ -41,7 +41,7 @@ classes: wide
     </ol>
 </section>
 <section id="bibliography">
-    <header><h1>Literature</h1></header>
+    <header><h2>Literature</h2></header>
     {% bibliography --cited %}
 </section>
 <script type="text/javascript">

--- a/_layouts/manuscript.html
+++ b/_layouts/manuscript.html
@@ -21,21 +21,23 @@ classes: wide
 <section id="questions">
     <header><h1>Questions</h1></header>
     <ol>
-        {% for q in page.questions %}<li>{{ site.data.questions[q] }}</li>{% endfor %}
+        {%- for q in page.questions %}
+        <li>{{ site.data.questions[q] }}</li>
+        {%- endfor %}
     </ol>
 </section>
 {% endif %}
 <section id="related">
     <header><h1>Related manuscripts</h1></header>
     <ol>
-        {% for ms in site.data.most_sim[page.shelfmark] %}
-        {% assign found_ms = site.manuscripts | find: "shelfmark", ms %}
-        {% if found_ms %}
+        {%- for ms in site.data.most_sim[page.shelfmark] %}
+        {%- assign found_ms = site.manuscripts | find: "shelfmark", ms %}
+        {%- if found_ms %}
         <li><a href="{{ found_ms.url }}" target="_blank">{{ ms }}</a></li>
-        {% else %}
+        {%- else %}
         <li>{{ ms }}</li>
-        {% endif %}
-        {% endfor %}
+        {%- endif %}
+        {%- endfor %}
     </ol>
 </section>
 <section id="bibliography">

--- a/_layouts/single-ms.html
+++ b/_layouts/single-ms.html
@@ -2,13 +2,13 @@
 layout: default-ms
 ---
 
-{% if page.header.overlay_color or page.header.overlay_image or page.header.image %}
+{%- if page.header.overlay_color or page.header.overlay_image or page.header.image %}
   {% include page__hero.html %}
 {% elsif page.header.video.id and page.header.video.provider %}
   {% include page__hero_video.html %}
 {% endif %}
 
-{% if page.url != "/" and site.breadcrumbs %}
+{%- if page.url != "/" and site.breadcrumbs %}
   {% unless paginator %}
     {% include breadcrumbs.html %}
   {% endunless %}
@@ -24,17 +24,16 @@ layout: default-ms
     {% if page.last_modified_at %}<meta itemprop="dateModified" content="{{ page.last_modified_at | date: "%B %d, %Y" }}">{% endif %}
 
     <div class="page__inner-wrap">
-      {% unless page.header.overlay_color or page.header.overlay_image %}
+      {%- unless page.header.overlay_color or page.header.overlay_image %}
         <header>
-          
-          {% if page.read_time %}
+          {%- if page.read_time %}
             <p class="page__meta"><i class="far fa-clock" aria-hidden="true"></i> {% include read-time.html %}</p>
-          {% endif %}
+          {%- endif %}
         </header>
-      {% endunless %}
+      {%- endunless %}
 
       <section class="page__content">
-        {% if page.toc %}
+        {%- if page.toc %}
           <aside class="sidebar__right {% if page.toc_sticky %}sticky{% endif %}">
             <nav class="toc">
               <header><h4 class="nav__title"><i class="fas fa-{{ page.toc_icon | default: 'file-alt' }}"></i> {{ page.toc_label | default: site.data.ui-text[site.locale].toc_label }}</h4></header>
@@ -47,24 +46,24 @@ layout: default-ms
       </section>
 
       <footer class="page__meta">
-        {% if site.data.ui-text[site.locale].meta_label %}
+        {%- if site.data.ui-text[site.locale].meta_label %}
           <h4 class="page__meta-title">{{ site.data.ui-text[site.locale].meta_label }}</h4>
         {% endif %}
-        {% if page.last_modified_at %}
+        {%- if page.last_modified_at %}
           <p class="page__date"><strong><i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.last_modified_at | date: "%Y-%m-%d" }}">{{ page.last_modified_at | date: "%B %d, %Y" }}</time></p>
-        {% elsif page.date %}
+        {%- elsif page.date %}
           <p class="page__date"><strong><i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %d, %Y" }}</time></p>
-        {% endif %}
+        {%- endif %}
       </footer>
 
-      {% if page.share %}{% include social-share.html %}{% endif %}
+      {%- if page.share %}{% include social-share.html %}{% endif %}
 
       {% include post_pagination.html %}
     </div>
 
-    {% if jekyll.environment == 'production' and site.comments.provider and page.comments %}
+    {%- if jekyll.environment == 'production' and site.comments.provider and page.comments %}
       {% include comments.html %}
-    {% endif %}
+    {%- endif %}
   </article>
 
   {% comment %}<!-- only show related on a post page when `related: true` -->{% endcomment %}


### PR DESCRIPTION
Use whitespace controls in the Liquid tags to produce less whitespace in the output. Also make sure there is just one `h1` element in a manuscript page by demoting the section headings to `h2`.