### PR TITLE
Move around items in route navigation

### DIFF
--- a/_layouts/manuscript.html
+++ b/_layouts/manuscript.html
@@ -4,12 +4,14 @@ classes: wide
 ---
 {% assign this_route = site.routes | where:"identifier",page.route | first %}
 {% assign this_ms = site.data.handles | where:"signatuur",page.shelfmark | first %}
-<header class="route-title"><a href="{{ this_route.url | relative_url }}" rel="up">{{ this_route.title }}</a></header>
-<nav class="ms-title">
-    <div id="prev"><a href="{{ page.previous.url | relative_url }}" rel="prev" title="Previous manuscript">☜</a></div>
+<header class="route-title">
+    <nav class="ms-title" aria-label="Route">
+        <div id="prev"><a href="{{ page.previous.url | relative_url }}" rel="prev" title="Previous manuscript">☜</a></div>
+        <a href="{{ this_route.url | relative_url }}" rel="up">{{ this_route.title }}</a>
+        <div id="next"><a href="{{ page.next.url | relative_url }}" rel="next" title="Next manuscript">☞</a></div>
+    </nav>
     <h1>{{ page.title }}</h1>
-    <div id="next"><a href="{{ page.next.url | relative_url }}" rel="next" title="Next manuscript">☞</a></div>
-</nav>
+</header>
 <section id="sect-viewer">
     <div id="viewer"></div>
     <div id="ms-identification"><span class="shelfmark"><a href="{{ this_ms.handle }}" title="See {{ page.shelfmark }} in Digital Collections">{{ page.shelfmark }}</a></span> ({{ page.origin }}, {{ page.ms_date }}):

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -102,22 +102,16 @@ nav.ms-title {
     display: flex !important;
     justify-content: space-between;
 }
-nav.ms-title > h1 {
-    display: inline-block;
-    text-align: center;
+nav.ms-title > * {
+    align-content: center;
 }
-#prev {
-    /* align-content: start; */
+#prev, #next {
     font-size: 3em;
-    width: 100px;
-    display: inline-block;
+    line-height: normal;
 }
 
-#next {
-    text-align: end;
-    font-size: 3em;
-    width: 100px;
-    display: inline-block;
+h1 {
+    text-align: center;
 }
 
 #description {


### PR DESCRIPTION
The main title of the page comes after the navigation, while the link to the route moves inside the navigation.