### PR TITLE
Create separate configs for development and production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site
+_site_dev
 .sass-cache
 .jekyll-metadata
 node_modules/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ To build the website once, so that it can be deployed, run:
 bundle exec jekyll build
 ```
 
+To build the website once, so that it can be deployed to the development
+environment, run:
+
+```sh
+bundle exec jekyll build --config _config.yml,_config.dev.yml
+```
+
 To continuously build the website on every change, run:
 
 ```sh
@@ -36,9 +43,12 @@ And open the locally served page: <http://localhost:4000/>.
 ## Deploy
 
 To deploy the built website, copy all the contents of the `_site` directory
-to the directory that is served as the root of [DigManClass].
+(or the `_site_dev` directory for a development build)
+to the directory that is served as the root of [DigManClass] (or 
+[DigManClass-d]).
 
 [DigManClass]: https://digmanclass.universiteitleiden.nl/
+[DigManClass-d]: https://digmanclass-d.universiteitleiden.nl/
 
 ## Contributing
 

--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -1,0 +1,2 @@
+url: "https://digmanclass-d.universiteitleiden.nl" # the base hostname & protocol for your site, e.g. http://example.com
+destination: ./_site_dev

--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   We offer digital manuscripts for your classroom.
 #baseurl: "/" # the subpath of your site, e.g. /blog
 url: "https://digmanclass.universiteitleiden.nl" # the base hostname & protocol for your site, e.g. http://example.com
-twitter_username: ubleiden
+# twitter_username: ubleiden
 github_username:  LeidenUniversityLibrary
 
 collections:


### PR DESCRIPTION
This allows to build and deploy for both the development and production environment and includes commands in the README. Using the combined default and dev config, the site URL and output directory are overridden. This relates to #35 but does not directly solve it.

Having separate output directories should make it easier to collect the outputs in an archive file without accidentally deploying to the wrong environment.

Minor additional change: remove the Twitter handle.